### PR TITLE
Namespaced headings so that more than one can be used in a pattern.

### DIFF
--- a/components/_patterns/00-base/layouts/grid/00-grid.twig
+++ b/components/_patterns/00-base/layouts/grid/00-grid.twig
@@ -1,7 +1,7 @@
 {% if grid_label %}
 {% include "@atoms/02-text/00-headings/heading-2/heading-2.twig"
   with {
-    "heading": grid_label,
+    "heading_2": grid_label,
   }
 %}
 {% endif %}

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-1/heading-1.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-1/heading-1.twig
@@ -14,6 +14,6 @@
 #}
 {{ title_prefix }}
 {% if title %}
-  <h1 class="heading-1{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h1>
+  <h1 class="heading-1{% if variation %}--{{ variation }}{% endif %}">{{ heading_1 }}</h1>
 {% endif %}
 {{ title_suffix }}

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-1/heading-1.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-1/heading-1.yml
@@ -1,2 +1,2 @@
-heading:
+heading_1:
   "This is a Header 1 styling isn't it cool"

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-2/heading-2.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-2/heading-2.twig
@@ -1,1 +1,1 @@
-<h2 class="heading-2{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h2>
+<h2 class="heading-2{% if variation %}--{{ variation }}{% endif %}">{{ heading_2 }}</h2>

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-2/heading-2.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-2/heading-2.yml
@@ -1,2 +1,2 @@
-heading:
+heading_2:
   "This is a Header 2 styling"

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-3/heading-3.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-3/heading-3.twig
@@ -1,1 +1,1 @@
-<h3 class="heading-3{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h3>
+<h3 class="heading-3{% if variation %}--{{ variation }}{% endif %}">{{ heading_3 }}</h3>

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-3/heading-3.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-3/heading-3.yml
@@ -1,2 +1,2 @@
-heading:
+heading_3:
   "This is a Header 3 styling"

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-4/heading-4.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-4/heading-4.twig
@@ -1,1 +1,1 @@
-<h4 class="heading-4{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h4>
+<h4 class="heading-4{% if variation %}--{{ variation }}{% endif %}">{{ heading_4 }}</h4>

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-4/heading-4.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-4/heading-4.yml
@@ -1,2 +1,2 @@
-heading:
+heading_4:
   "This is a Header 4 styling"

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-5/heading-5.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-5/heading-5.twig
@@ -1,1 +1,1 @@
-<h5 class="heading-5{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h5>
+<h5 class="heading-5{% if variation %}--{{ variation }}{% endif %}">{{ heading_5 }}</h5>

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-5/heading-5.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-5/heading-5.yml
@@ -1,2 +1,2 @@
-heading:
+heading_5:
   "This is a Header 5 styling"

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-6/heading-6.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-6/heading-6.twig
@@ -1,1 +1,1 @@
-<h6 class="heading-6{% if variation %}--{{ variation }}{% endif %}">{{ heading }}</h6>
+<h6 class="heading-6{% if variation %}--{{ variation }}{% endif %}">{{ heading_6 }}</h6>

--- a/components/_patterns/01-atoms/02-text/00-headings/heading-6/heading-6.yml
+++ b/components/_patterns/01-atoms/02-text/00-headings/heading-6/heading-6.yml
@@ -1,2 +1,2 @@
-heading:
+heading_6:
   "This is a Header 6 styling"

--- a/docs/drupal-components.md
+++ b/docs/drupal-components.md
@@ -6,12 +6,12 @@ From your Drupal Twig templates in `templates/` you can use Twig's `{% include %
 
 ### Passing Variables
 
-One of the biggest benefits of this component system is being able to give  concise, logical names to your variables. However, Drupal has it's own variable syntax that you will need to leverage to pass data. Below is an example from the page title template (`templates/page-title.html.twig`) of how to pass that data using Twig's `{% include %}` statement. Notice that the component uses a   `{{ heading }}` variable but the Drupal template uses `{{ title }}`. Simply pass the Drupal variable to the component variable as follows:
+One of the biggest benefits of this component system is being able to give  concise, logical names to your variables. However, Drupal has it's own variable syntax that you will need to leverage to pass data. Below is an example from the page title template (`templates/page-title.html.twig`) of how to pass that data using Twig's `{% include %}` statement. Notice that the component uses a   `{{ heading_1 }}` variable but the Drupal template uses `{{ title }}`. Simply pass the Drupal variable to the component variable as follows:
 
 ```
 {% include "@atoms/02-text/00-headings/heading-1/heading-1.twig"
   with {
-    "heading": title
+    "heading_1": title
   }
 %}
 ```
@@ -30,7 +30,7 @@ Below is a more complex example:
 
 ### Drupal-specific functions, filters and tags
 
-Drupal has specific Twig functions, filters, tags, etc. that it uses that Pattern Lab is not aware of. Pattern Lab has an easy way to add those though, which is in components/\_twig-components/. There are examples of filters and functions already in there (currently you can use the `t()` and `without()` filters and the `kint()` function). Documentation on how to add these can be found [here](https://github.com/pattern-lab/patternengine-php-twig#extending-twig-further).  
+Drupal has specific Twig functions, filters, tags, etc. that it uses that Pattern Lab is not aware of. Pattern Lab has an easy way to add those though, which is in components/\_twig-components/. There are examples of filters and functions already in there (currently you can use the `t()` and `without()` filters and the `kint()` function). Documentation on how to add these can be found [here](https://github.com/pattern-lab/patternengine-php-twig#extending-twig-further).
 
 ## JavaScript in Drupal
 

--- a/templates/content/page-title.html.twig
+++ b/templates/content/page-title.html.twig
@@ -14,6 +14,6 @@
 #}
 {% include "@atoms/02-text/00-headings/heading-1/heading-1.twig"
   with {
-    "heading": title
+    "heading_1": title
   }
 %}


### PR DESCRIPTION
Simple update to headings so that you can use an h2 and an h3 for example in the same pattern, and not have issues with them both being called {{ heading }}.