### PR TITLE
Add a better t filter to pattern lab so it plays well with Drupal

### DIFF
--- a/components/_twig-components/filters/t.filter.php
+++ b/components/_twig-components/filters/t.filter.php
@@ -6,6 +6,12 @@
  * Bring Drupal filters in just so Pattern Lab doesn't bork.
  */
 
-$filter = new Twig_SimpleFilter('t', function ($string) {
-  return $string;
+$filter = new Twig_SimpleFilter('t', function ($string, $array = array()) {
+  if (is_string($string) && is_array($array)) {
+    $haystack = $string;
+    foreach ($array as $needle => $replace) {
+      $haystack = str_replace($needle, $replace, $haystack);
+    }
+    return $haystack;
+  }
 });


### PR DESCRIPTION
## Purpose:
- Add a better t filter to pattern lab so it plays well with Drupal

## Description:
- While looking at the pager example I noticed that someone had copied and pasted a Drupal template.
- I then realized that the t function we were using in Pattern lab didn't support string replacements.
- Now it does.

## NOTE:
- We should discuss if we are merging straight to master or using the develop branch.  I recently updated the `develop` branch because it was very out of date against `master`
- Looks like other functions we might want to implement are found here: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Template%21TwigExtension.php/class/TwigExtension/8.2.x
- Another Drupal.Org page: https://www.drupal.org/docs/8/theming/twig/functions-in-twig-templates

## Testing:
- Go to the pager molecule and hover over the page numbers.  This fix should now display "Go to page 3" instead of "Go to page @key"