### PR TITLE
55: removed font-size mixin in favor of rems, fixed card paragraph re…

### DIFF
--- a/components/_patterns/00-base/_01-variables.scss
+++ b/components/_patterns/00-base/_01-variables.scss
@@ -2,9 +2,6 @@
 
 /// Widths and base sizing
 $max-width: 1200px;
-$base-font-size: 62.5%; // setup to work with rems
-$base-border-size: 5px;
-$measure-max: 675px; // use for paragraph measure.
 
 // Fonts
 $body: Georgia, Times, "Times New Roman", serif;

--- a/components/_patterns/00-base/_mixins.scss
+++ b/components/_patterns/00-base/_mixins.scss
@@ -1,15 +1,6 @@
 /////////////////////
 // Mixins
 
-/// Mixin - Font-Size.
-/// Adds px value for fallback - then rem value
-/// use example =   @include font-size(1.6); = 1.6rem / 16px
-
-@mixin font-size($sizeValue: 1.6) {
-  font-size: ($sizeValue * 10) + px;
-  font-size: $sizeValue + rem;
-}
-
 /// Mixin - Clearfix.
 /// Adds clearfix based on http://bourbon.io/docs/#clearfix
 /// use example =   @include cleafix
@@ -61,7 +52,7 @@
 /// Used in a number of views
 @mixin more-link {
   a {
-    @include font-size(.9);
+    font-size: .9rem;
     font-weight: 600;
     text-decoration: none;
 
@@ -77,7 +68,7 @@
 /// Used in a number of views
 @mixin back-link {
   display: block;
-  @include font-size(.9);
+  font-size: .9rem;
   font-weight: 600;
   text-decoration: none;
 
@@ -91,7 +82,7 @@
 /// Mixin - Body Copy
 @mixin body-copy {
   font-family: $body;
-  @include font-size(.9);
+  font-size: .9rem;
   line-height: 1.6em;
 }
 

--- a/components/_patterns/01-atoms/06-buttons/_buttons.scss
+++ b/components/_patterns/01-atoms/06-buttons/_buttons.scss
@@ -20,7 +20,7 @@
 
   &--alt {
     font-weight: 600;
-    @include font-size(.7);
+    font-size: .7rem;
     background-color: $gray;
     padding: .4em .6em .3em;
 
@@ -32,7 +32,7 @@
   &--alt-2 {
     background-color: $gray-lightest;
     color: $black;
-    @include font-size(.8);
+    font-size: .8rem;
     font-weight: 600;
     text-transform: none;
 

--- a/components/_patterns/02-molecules/accordion-item/_accordion-item.scss
+++ b/components/_patterns/02-molecules/accordion-item/_accordion-item.scss
@@ -4,7 +4,7 @@
     color: $gray-dark;
     cursor: pointer;
     display: block;
-    @include font-size(1);
+    font-size: 1rem;
     font-weight: 600;
     padding:1em 0;
 

--- a/components/_patterns/02-molecules/card/01-card.twig
+++ b/components/_patterns/02-molecules/card/01-card.twig
@@ -92,7 +92,7 @@
       {% endif %}
       {% if card_body %}
         <div class="{{ card_body_base_class|default('body') }}{% for modifier in card_modifiers %} {{ card_body_base_class|default('body') }}--{{ modifier }}{% endfor %}{% if card_blockname %} {{ card_blockname }}__{{ card_body_base_class|default('body') }}{% endif %}">
-          {% include "@atoms/02-text/text/01-paragraph/paragraph.twig"
+          {% include "@atoms/02-text/text/01-paragraph.twig"
             with {
               "paragraph_content": card_body,
               "paragraph_base_class": card_body_base_class|default('body'),

--- a/components/_patterns/02-molecules/menus/inline-menu/_menu.scss
+++ b/components/_patterns/02-molecules/menus/inline-menu/_menu.scss
@@ -16,7 +16,7 @@
 }
 
 .menu__link {
-  @include font-size(.75);
+  font-size: .75rem;
   font-weight: 600;
   letter-spacing: 1.5px;
   text-decoration: none;


### PR DESCRIPTION
Addresses: https://github.com/fourkitchens/emulsify/issues/55

- Removes font-size mixin in favor of using rems
- Fixes card paragraph include issue