### PR TITLE
moved stylint dep to emulsify-gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,5 @@
   "scripts": {
     "start": "gulp clean && gulp compile && gulp theme",
     "postinstall": "rm -rf pattern-lab && composer create-project -n pattern-lab/edition-twig-standard pattern-lab && rm -rf pattern-lab/source && ln -s ../components pattern-lab/source"
-  },
-  "dependencies": {
-    "stylelint": "^7.10.1",
-    "stylelint-config-standard": "^16.0.0"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/fourkitchens/emulsify-gulp/pull/37

**To test:**
- [ ] Checkout this branch and `rm -rf node_modules`
- [ ] `yarn install` and ensure no errors

To-do:
- [ ] Change `"emulsify-gulp": "fourkitchens/emulsify-gulp#sldep",` to `"emulsify-gulp": "fourkitchens/emulsify-gulp",` after deploying https://github.com/fourkitchens/emulsify-gulp/pull/37