### PR TITLE
Add basic drush script to create an Emulsify based theme

### DIFF
--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -12,19 +12,19 @@ function emulsify_drush_command() {
   $items = array();
 
   $items['emulsify'] = array(
-    'description' => 'Create an Emulsify subtheme.',
+    'description' => 'Create an Emulsify theme.',
     'arguments' => array(
-      'name'         => 'The name of your subtheme.',
+      'name'         => 'The name of your theme.',
     ),
     'options' => array(
-      'machine_name' => 'The machine-readable name of your subtheme. This will be auto-generated from the human-readable name if ommited.',
-      'description' => 'The description of your subtheme',
-      'path' => 'The destination of your subtheme. Defaults to "all" (themes).',
+      'machine_name' => 'The machine-readable name of your theme. This will be auto-generated from the human-readable name if ommited.',
+      'description' => 'The description of your theme',
+      'path' => 'The destination of your theme. Defaults to "all" (themes).',
       'slim' => 'Only copy base files',
     ),
     'examples' => array(
-      'drush emulsify "subtheme"' => 'Creates an Emulsify subtheme called "subtheme", using the default options.',
-      'drush emulsify "subtheme" --machine_name=subtheme' => 'Creates a Emulsify subtheme called "subtheme" with a specific machine name.',
+      'drush emulsify "theme"' => 'Creates an Emulsify theme called "theme", using the default options.',
+      'drush emulsify "theme" --machine_name=theme' => 'Creates a Emulsify theme called "theme" with a specific machine name.',
     ),
   );
 
@@ -37,7 +37,7 @@ function emulsify_drush_command() {
 function emulsify_drush_help($section) {
   switch ($section) {
     case 'drush:emulsify':
-      return dt('This command will create an Emulsify subtheme. See examples to get started.');
+      return dt('This command will create an Emulsify theme. See examples to get started.');
   }
 }
 
@@ -71,42 +71,42 @@ function drush_emulsify($name = NULL) {
   );
   $machine_name = preg_replace($search, '', $machine_name);
 
-  // Description of subtheme.
+  // Description of theme.
   $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'Theme that uses Pattern Lab v2.';
 
-  // Determine the path to the new subtheme.
-  $subtheme_path = 'themes';
+  // Determine the path to the new theme.
+  $theme_path = 'themes/custom';
   if ($path = drush_get_option('path')) {
-    $subtheme_path = drush_trim_path($path);
+    $theme_path = drush_trim_path($path);
   }
 
-  drush_emulsify_create($name, $machine_name, $description, $subtheme_path);
+  drush_emulsify_create($name, $machine_name, $description, $theme_path);
 }
 
 /**
  * Create frontend theme.
  */
-function drush_emulsify_create($name, $machine_name, $description, $subtheme_path) {
-  $subtheme_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . $subtheme_path . '/' . $machine_name);
+function drush_emulsify_create($name, $machine_name, $description, $theme_path) {
+  $theme_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . $theme_path . '/' . $machine_name);
 
-  if (!is_dir(dirname($subtheme_path))) {
-    drush_die(dt('The directory "!directory" was not found.', array('!directory' => dirname($subtheme_path))));
+  if (!is_dir(dirname($theme_path))) {
+    drush_die(dt('The directory "!directory" was not found.', array('!directory' => dirname($theme_path))));
   }
 
   // Phase 1: Copy files.
   $files_to_copy = _emulsify_get_files_to_copy();
-  _emulsify_copy_files($files_to_copy, $subtheme_path);
+  _emulsify_copy_files($files_to_copy, $theme_path);
 
   // Phase 2: Alter files.
   $alterations = _emulsify_get_alterations($name, $machine_name);
   $files_to_alter = _emulsify_get_files_to_alter();
-  _emulsify_alter_files($subtheme_path, $files_to_alter, $alterations);
+  _emulsify_alter_files($theme_path, $files_to_alter, $alterations);
 
   // Phase 3: Rename files.
   $files_to_rename = _emulsify_get_files_to_rename();
-  _emulsify_rename_files($subtheme_path, $machine_name, $files_to_rename);
+  _emulsify_rename_files($theme_path, $machine_name, $files_to_rename);
 
-  _emulsify_notify($name, $subtheme_path);
+  _emulsify_notify($name, $theme_path);
 }
 
 /**
@@ -217,7 +217,7 @@ function _emulsify_get_files_to_rename() {
 /**
  * Alter strings within files.
  */
-function _emulsify_alter_files($subtheme_path, $files_to_alter = array(), $alterations = array(), $absolute = FALSE) {
+function _emulsify_alter_files($theme_path, $files_to_alter = array(), $alterations = array(), $absolute = FALSE) {
   if (empty($files_to_alter) || empty($alterations)) {
     return TRUE;
   }
@@ -227,13 +227,13 @@ function _emulsify_alter_files($subtheme_path, $files_to_alter = array(), $alter
       $file_path = $file_to_replace;
     }
     else {
-      $file_type = filetype($subtheme_path . DIRECTORY_SEPARATOR . $file_to_replace);
-      $file_path = $subtheme_path . DIRECTORY_SEPARATOR . $file_to_replace;
+      $file_type = filetype($theme_path . DIRECTORY_SEPARATOR . $file_to_replace);
+      $file_path = $theme_path . DIRECTORY_SEPARATOR . $file_to_replace;
     }
 
     if ($file_type === 'dir') {
       $files = file_scan_directory($file_path, '/\.*/');
-      _emulsify_alter_files($subtheme_path, array_keys($files), $alterations, TRUE);
+      _emulsify_alter_files($theme_path, array_keys($files), $alterations, TRUE);
     }
     elseif ($file_type === 'file') {
       _emulsify_file_str_replace($file_path, array_keys($alterations), $alterations);
@@ -266,10 +266,10 @@ function _emulsify_copy_files($files = array(), $destination_path = '') {
 /**
  * Rename files.
  */
-function _emulsify_rename_files($subtheme_path, $machine_name, $files_to_rename = array()) {
+function _emulsify_rename_files($theme_path, $machine_name, $files_to_rename = array()) {
   foreach ($files_to_rename as $file_to_rename_path) {
-    $file_original_path = $subtheme_path . DIRECTORY_SEPARATOR . $file_to_rename_path;
-    $file_new_path = $subtheme_path . DIRECTORY_SEPARATOR . str_replace('emulsify', $machine_name, $file_to_rename_path);
+    $file_original_path = $theme_path . DIRECTORY_SEPARATOR . $file_to_rename_path;
+    $file_new_path = $theme_path . DIRECTORY_SEPARATOR . str_replace('emulsify', $machine_name, $file_to_rename_path);
     drush_op('rename', drush_normalize_path($file_original_path), drush_normalize_path($file_new_path));
   }
 }
@@ -287,13 +287,13 @@ function _emulsify_file_str_replace($file_path, $find, $replace) {
 /**
  * Notifies the user of success.
  */
-function _emulsify_notify($name, $subtheme_path) {
+function _emulsify_notify($name, $theme_path) {
   // Notify user of the newly created theme.
-  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path, you can now run \'yarn\' or \'npm install\' to install the node modules.';
+  $message = 'Successfully created the Emulsify theme "!name" created in: !path, you can now run \'yarn\' or \'npm install\' to install the node modules.';
 
   $message = dt($message, array(
     '!name' => $name,
-    '!path' => $subtheme_path,
+    '!path' => $theme_path,
   ));
   drush_print($message);
 }

--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -20,11 +20,11 @@ function emulsify_drush_command() {
       'machine_name' => 'The machine-readable name of your subtheme. This will be auto-generated from the human-readable name if ommited.',
       'description' => 'The description of your subtheme',
       'path' => 'The destination of your subtheme. Defaults to "all" (themes).',
-      'kit' => 'The name or url of the starter kit to use. Defaults to "elysium".',
+      'slim' => 'Only copy base files',
     ),
     'examples' => array(
-      'drush emulsify "Elysium"' => 'Creates an Emulsify subtheme called "Elysium", using the default options.',
-      'drush emulsify "Elysium" --machine_name=elysium' => 'Creates a Emulsify subtheme called "Elysium" with a specific machine name.',
+      'drush emulsify "subtheme"' => 'Creates an Emulsify subtheme called "subtheme", using the default options.',
+      'drush emulsify "subtheme" --machine_name=subtheme' => 'Creates a Emulsify subtheme called "subtheme" with a specific machine name.',
     ),
   );
 
@@ -44,7 +44,7 @@ function emulsify_drush_help($section) {
 /**
  * Implements drush_hook_COMMAND().
  */
-function drush_emulsify($name = NULL, $machine_name = NULL) {
+function drush_emulsify($name = NULL) {
 
   // If no $name provided, abort.
   if (!$name) {
@@ -58,9 +58,7 @@ function drush_emulsify($name = NULL, $machine_name = NULL) {
   }
 
   // Determine the machine name.
-  if (!isset($machine_name)) {
-    $machine_name = drush_get_option('machine_name');
-  }
+  $machine_name = drush_get_option('machine_name');
   if (!$machine_name) {
     $machine_name = $name;
   }
@@ -74,7 +72,7 @@ function drush_emulsify($name = NULL, $machine_name = NULL) {
   $machine_name = preg_replace($search, '', $machine_name);
 
   // Description of subtheme.
-  $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'A theme based on Emulsify.';
+  $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'Theme that uses Pattern Lab v2.';
 
   // Determine the path to the new subtheme.
   $subtheme_path = 'themes';
@@ -82,91 +80,204 @@ function drush_emulsify($name = NULL, $machine_name = NULL) {
     $subtheme_path = drush_trim_path($path);
   }
 
-  // Determine the kit to use.
-  $kit = (drush_get_option('kit')) ? drush_trim_path(drush_get_option('kit')) : 'elysium';
-
-  drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit);
-  drush_emulsify_admin_create($name, $machine_name, $description, $subtheme_path, $kit);
+  drush_emulsify_create($name, $machine_name, $description, $subtheme_path);
 }
 
 /**
  * Create frontend theme.
  */
-function drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit) {
+function drush_emulsify_create($name, $machine_name, $description, $subtheme_path) {
   $subtheme_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . $subtheme_path . '/' . $machine_name);
-
-  // Make a fresh copy of the kit.
-  $kit_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . drupal_get_path('theme', 'emulsify') . '/kits/' . $kit);
 
   if (!is_dir(dirname($subtheme_path))) {
     drush_die(dt('The directory "!directory" was not found.', array('!directory' => dirname($subtheme_path))));
   }
-  drush_op('drush_copy_dir', $kit_path, $subtheme_path);
 
-  // Alter the contents of the .info file based on the command options.
-  $alterations = array(
-    'ELYSIUM_NAME' => $name,
-    'ELYSIUM_DESCRIPTION' => $description,
-    'elysium' => $machine_name,
-    'hidden: true' => '',
-  );
+  // Phase 1: Copy files.
+  $files_to_copy = _emulsify_get_files_to_copy();
+  _emulsify_copy_files($files_to_copy, $subtheme_path);
 
-  // Replace all occurrences of '{{machine_name}}' with the machine name of our
-  // sub theme.
-  $files_to_replace = emulsify_get_files_to_make_replacements($kit);
-  foreach ($files_to_replace as $file_to_replace) {
-    drush_op('emulsify_file_str_replace', $subtheme_path . '/' . $file_to_replace, array_keys($alterations), $alterations);
-  }
+  // Phase 2: Alter files.
+  $alterations = _emulsify_get_alterations($name, $machine_name);
+  $files_to_alter = _emulsify_get_files_to_alter();
+  _emulsify_alter_files($subtheme_path, $files_to_alter, $alterations);
 
-  // Rename files.
-  $files_to_rename = array(
-    '{{kit}}.info.yml',
-    '{{kit}}.libraries.yml',
-    '{{kit}}.breakpoints.yml',
-    '{{kit}}.theme',
-    'dev/scss/{{kit}}.scss',
-    'dev/js/{{kit}}.js',
-    'config/schema/{{kit}}.schema.yml',
-  );
-  foreach ($files_to_rename as $file_to_rename_path) {
-    $file_original_path = $subtheme_path . '/' . str_replace('{{kit}}', $kit, $file_to_rename_path);
-    $file_new_path = $subtheme_path . '/' . str_replace('{{kit}}', $machine_name, $file_to_rename_path);
-    drush_op('rename', drush_normalize_path($file_original_path), drush_normalize_path($file_new_path));
-  }
+  // Phase 3: Rename files.
+  $files_to_rename = _emulsify_get_files_to_rename();
+  _emulsify_rename_files($subtheme_path, $machine_name, $files_to_rename);
 
-  // Batch rename all config files.
-  $includes_path = $subtheme_path . '/config/optional/*.yml';
-  foreach (glob($includes_path) as $file_to_rename_path) {
-    $file_new_path = str_replace($kit, $machine_name, $file_to_rename_path);
-    drush_op('rename', drush_normalize_path($file_to_rename_path), drush_normalize_path($file_new_path));
-    drush_op('emulsify_file_str_replace', $file_new_path, array_keys($alterations), $alterations);
-  }
-
-  // Notify user of the newly created theme.
-  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path using the "!kit" kit';
-
-  $message = dt($message . '.', array(
-    '!name' => $name,
-    '!path' => $subtheme_path,
-    '!kit' => $kit,
-  ));
-  drush_print($message);
+  _emulsify_notify($name, $subtheme_path);
 }
 
 /**
- * Create admin theme.
+ * Gets files to copy.
+ *
+ * This function supports both directories and individual files.  Alterations
+ * happen in sequential order so you can replace something that was previously
+ * replaced.
  */
-function drush_emulsify_admin_create($name, $machine_name, $description, $subtheme_path, $kit) {
-  $name .= ' Admin';
-  $machine_name .= '_admin';
-  $kit .= '_admin';
-  // drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit);
+function _emulsify_get_alterations($name, $machine_name) {
+  return array(
+    'Emulsify' => $name,
+    'emulsify' => $machine_name,
+    'hidden: true' => '',
+  );
+}
+
+/**
+ * Returns an array of files to make string replacements.
+ */
+function _emulsify_get_files_to_alter() {
+  // Slim files and directories declaration.
+  $slim_array = array(
+    'components',
+    'emulsify.info.yml',
+    'emulsify.theme',
+  );
+  // If we would like to have a bare copy we use is slim option.
+  if (drush_get_option('slim') === TRUE) {
+    return $slim_array;
+  }
+  else {
+    return array_merge($slim_array, array(
+      'templates',
+      'emulsify.breakpoints.yml',
+      'emulsify.libraries.yml',
+      'README.md',
+    ));
+  }
+}
+
+/**
+ * Gets files to copy.
+ *
+ * This function supports both directories and individual files.
+ *
+ * The following directories/files will never be copied:
+ * node_modules/
+ * github.com/
+ * composer.json
+ * LICENSE.txt
+ * emulsify.drush.inc
+ */
+function _emulsify_get_files_to_copy() {
+  // Slim files and directories declaration.
+  $slim_array = array(
+    'components',
+    'pattern-lab',
+    '.editorconfig',
+    '.gitignore',
+    '.stylelintrc',
+    'emulsify.info.yml',
+    'emulsify.theme',
+    'gulpfile.js',
+    'package.json',
+    'yarn.lock',
+  );
+  // If we would like to have a bare copy we use is slim option.
+  if (drush_get_option('slim') === TRUE) {
+    return $slim_array;
+  }
+  else {
+    return array_merge($slim_array, array(
+      'css',
+      'dist',
+      'fonts',
+      'images',
+      'templates',
+      'emulsify.breakpoints.yml',
+      'emulsify.libraries.yml',
+      'README.md',
+      'screenshot.png',
+    ));
+  }
+}
+
+/**
+ * Get files to rename.
+ */
+function _emulsify_get_files_to_rename() {
+  // Slim files and directories declaration.
+  $slim_array = array(
+    'emulsify.info.yml',
+    'emulsify.theme',
+  );
+  // If we would like to have a bare copy we use is slim option.
+  if (drush_get_option('slim') === TRUE) {
+    return $slim_array;
+  }
+  else {
+    return array_merge($slim_array, array(
+      'emulsify.breakpoints.yml',
+      'emulsify.libraries.yml',
+    ));
+  }
+}
+
+/**
+ * Alter strings within files.
+ */
+function _emulsify_alter_files($subtheme_path, $files_to_alter = array(), $alterations = array(), $absolute = FALSE) {
+  if (empty($files_to_alter) || empty($alterations)) {
+    return TRUE;
+  }
+  foreach ($files_to_alter as $file_to_replace) {
+    if ($absolute === TRUE) {
+      $file_type = filetype($file_to_replace);
+      $file_path = $file_to_replace;
+    }
+    else {
+      $file_type = filetype($subtheme_path . DIRECTORY_SEPARATOR . $file_to_replace);
+      $file_path = $subtheme_path . DIRECTORY_SEPARATOR . $file_to_replace;
+    }
+
+    if ($file_type === 'dir') {
+      $files = file_scan_directory($file_path, '/\.*/');
+      _emulsify_alter_files($subtheme_path, array_keys($files), $alterations, TRUE);
+    }
+    elseif ($file_type === 'file') {
+      _emulsify_file_str_replace($file_path, array_keys($alterations), $alterations);
+    }
+  }
+}
+
+/**
+ * Copy files.
+ *
+ * @param array $files
+ *   An array of files (strings) to copy.
+ * @param string $destination_path
+ *   A string representing the destination path.
+ *
+ * @return bool
+ *   A boolean representing the success or failure of the command.
+ */
+function _emulsify_copy_files($files = array(), $destination_path = '') {
+  if (empty($files) || empty($destination_path)) {
+    return FALSE;
+  }
+  file_prepare_directory($destination_path, FILE_CREATE_DIRECTORY);
+  foreach ($files as $files_to_copy) {
+    drush_copy_dir(__DIR__ . DIRECTORY_SEPARATOR . $files_to_copy, $destination_path . DIRECTORY_SEPARATOR . $files_to_copy);
+  }
+  return TRUE;
+}
+
+/**
+ * Rename files.
+ */
+function _emulsify_rename_files($subtheme_path, $machine_name, $files_to_rename = array()) {
+  foreach ($files_to_rename as $file_to_rename_path) {
+    $file_original_path = $subtheme_path . DIRECTORY_SEPARATOR . $file_to_rename_path;
+    $file_new_path = $subtheme_path . DIRECTORY_SEPARATOR . str_replace('emulsify', $machine_name, $file_to_rename_path);
+    drush_op('rename', drush_normalize_path($file_original_path), drush_normalize_path($file_new_path));
+  }
 }
 
 /**
  * Replace strings in a file.
  */
-function emulsify_file_str_replace($file_path, $find, $replace) {
+function _emulsify_file_str_replace($file_path, $find, $replace) {
   $file_path = drush_normalize_path($file_path);
   $file_contents = file_get_contents($file_path);
   $file_contents = str_replace($find, $replace, $file_contents);
@@ -174,22 +285,15 @@ function emulsify_file_str_replace($file_path, $find, $replace) {
 }
 
 /**
- * Returns an array of files to make string replacements.
+ * Notifies the user of success.
  */
-function emulsify_get_files_to_make_replacements($kit = 'elysium') {
-  return array(
-    'config/install/' . $kit . '.settings.yml',
-    'config/schema/' . $kit . '.schema.yml',
-    'dev/scss/' . $kit . '.scss',
-    'dev/js/' . $kit . '.js',
-    'dev/bower.json',
-    'dev/gulpfile.js',
-    'dev/package.json',
-    'dev/config/config.json',
-    $kit . '.info.yml',
-    $kit . '.libraries.yml',
-    $kit . '.breakpoints.yml',
-    $kit . '.theme',
-    'README.md',
-  );
+function _emulsify_notify($name, $subtheme_path) {
+  // Notify user of the newly created theme.
+  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path';
+
+  $message = dt($message . '.', array(
+    '!name' => $name,
+    '!path' => $subtheme_path,
+  ));
+  drush_print($message);
 }

--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -289,9 +289,9 @@ function _emulsify_file_str_replace($file_path, $find, $replace) {
  */
 function _emulsify_notify($name, $subtheme_path) {
   // Notify user of the newly created theme.
-  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path, you can now run yarn to install the node modules.';
+  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path, you can now run \'yarn\' or \'npm install\' to install the node modules.';
 
-  $message = dt($message . '.', array(
+  $message = dt($message, array(
     '!name' => $name,
     '!path' => $subtheme_path,
   ));

--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * @file
+ * Contains Drush hooks. Inspired by Aeon drush commands.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function emulsify_drush_command() {
+  $items = array();
+
+  $items['emulsify'] = array(
+    'description' => 'Create an Emulsify subtheme.',
+    'arguments' => array(
+      'name'         => 'The name of your subtheme.',
+    ),
+    'options' => array(
+      'machine_name' => 'The machine-readable name of your subtheme. This will be auto-generated from the human-readable name if ommited.',
+      'description' => 'The description of your subtheme',
+      'path' => 'The destination of your subtheme. Defaults to "all" (themes).',
+      'kit' => 'The name or url of the starter kit to use. Defaults to "elysium".',
+    ),
+    'examples' => array(
+      'drush emulsify "Elysium"' => 'Creates an Emulsify subtheme called "Elysium", using the default options.',
+      'drush emulsify "Elysium" --machine_name=elysium' => 'Creates a Emulsify subtheme called "Elysium" with a specific machine name.',
+    ),
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_drush_help().
+ */
+function emulsify_drush_help($section) {
+  switch ($section) {
+    case 'drush:emulsify':
+      return dt('This command will create an Emulsify subtheme. See examples to get started.');
+  }
+}
+
+/**
+ * Implements drush_hook_COMMAND().
+ */
+function drush_emulsify($name = NULL, $machine_name = NULL) {
+
+  // If no $name provided, abort.
+  if (!$name) {
+    drush_print(dt('Theme name missing. See help using drush emulsify --help.'));
+    return;
+  }
+
+  // Determine the theme name.
+  if (!isset($name)) {
+    $name = drush_get_option('name');
+  }
+
+  // Determine the machine name.
+  if (!isset($machine_name)) {
+    $machine_name = drush_get_option('machine_name');
+  }
+  if (!$machine_name) {
+    $machine_name = $name;
+  }
+  $machine_name = str_replace(' ', '_', strtolower($machine_name));
+  $search = array(
+    // Remove characters not valid in function names.
+    '/[^a-z0-9_]/',
+    // Functions must begin with an alpha character.
+    '/^[^a-z]+/',
+  );
+  $machine_name = preg_replace($search, '', $machine_name);
+
+  // Description of subtheme.
+  $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'A theme based on Emulsify.';
+
+  // Determine the path to the new subtheme.
+  $subtheme_path = 'themes';
+  if ($path = drush_get_option('path')) {
+    $subtheme_path = drush_trim_path($path);
+  }
+
+  // Determine the kit to use.
+  $kit = (drush_get_option('kit')) ? drush_trim_path(drush_get_option('kit')) : 'elysium';
+
+  drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit);
+  drush_emulsify_admin_create($name, $machine_name, $description, $subtheme_path, $kit);
+}
+
+/**
+ * Create frontend theme.
+ */
+function drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit) {
+  $subtheme_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . $subtheme_path . '/' . $machine_name);
+
+  // Make a fresh copy of the kit.
+  $kit_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . drupal_get_path('theme', 'emulsify') . '/kits/' . $kit);
+
+  if (!is_dir(dirname($subtheme_path))) {
+    drush_die(dt('The directory "!directory" was not found.', array('!directory' => dirname($subtheme_path))));
+  }
+  drush_op('drush_copy_dir', $kit_path, $subtheme_path);
+
+  // Alter the contents of the .info file based on the command options.
+  $alterations = array(
+    'ELYSIUM_NAME' => $name,
+    'ELYSIUM_DESCRIPTION' => $description,
+    'elysium' => $machine_name,
+    'hidden: true' => '',
+  );
+
+  // Replace all occurrences of '{{machine_name}}' with the machine name of our
+  // sub theme.
+  $files_to_replace = emulsify_get_files_to_make_replacements($kit);
+  foreach ($files_to_replace as $file_to_replace) {
+    drush_op('emulsify_file_str_replace', $subtheme_path . '/' . $file_to_replace, array_keys($alterations), $alterations);
+  }
+
+  // Rename files.
+  $files_to_rename = array(
+    '{{kit}}.info.yml',
+    '{{kit}}.libraries.yml',
+    '{{kit}}.breakpoints.yml',
+    '{{kit}}.theme',
+    'dev/scss/{{kit}}.scss',
+    'dev/js/{{kit}}.js',
+    'config/schema/{{kit}}.schema.yml',
+  );
+  foreach ($files_to_rename as $file_to_rename_path) {
+    $file_original_path = $subtheme_path . '/' . str_replace('{{kit}}', $kit, $file_to_rename_path);
+    $file_new_path = $subtheme_path . '/' . str_replace('{{kit}}', $machine_name, $file_to_rename_path);
+    drush_op('rename', drush_normalize_path($file_original_path), drush_normalize_path($file_new_path));
+  }
+
+  // Batch rename all config files.
+  $includes_path = $subtheme_path . '/config/optional/*.yml';
+  foreach (glob($includes_path) as $file_to_rename_path) {
+    $file_new_path = str_replace($kit, $machine_name, $file_to_rename_path);
+    drush_op('rename', drush_normalize_path($file_to_rename_path), drush_normalize_path($file_new_path));
+    drush_op('emulsify_file_str_replace', $file_new_path, array_keys($alterations), $alterations);
+  }
+
+  // Notify user of the newly created theme.
+  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path using the "!kit" kit';
+
+  $message = dt($message . '.', array(
+    '!name' => $name,
+    '!path' => $subtheme_path,
+    '!kit' => $kit,
+  ));
+  drush_print($message);
+}
+
+/**
+ * Create admin theme.
+ */
+function drush_emulsify_admin_create($name, $machine_name, $description, $subtheme_path, $kit) {
+  $name .= ' Admin';
+  $machine_name .= '_admin';
+  $kit .= '_admin';
+  // drush_emulsify_create($name, $machine_name, $description, $subtheme_path, $kit);
+}
+
+/**
+ * Replace strings in a file.
+ */
+function emulsify_file_str_replace($file_path, $find, $replace) {
+  $file_path = drush_normalize_path($file_path);
+  $file_contents = file_get_contents($file_path);
+  $file_contents = str_replace($find, $replace, $file_contents);
+  file_put_contents($file_path, $file_contents);
+}
+
+/**
+ * Returns an array of files to make string replacements.
+ */
+function emulsify_get_files_to_make_replacements($kit = 'elysium') {
+  return array(
+    'config/install/' . $kit . '.settings.yml',
+    'config/schema/' . $kit . '.schema.yml',
+    'dev/scss/' . $kit . '.scss',
+    'dev/js/' . $kit . '.js',
+    'dev/bower.json',
+    'dev/gulpfile.js',
+    'dev/package.json',
+    'dev/config/config.json',
+    $kit . '.info.yml',
+    $kit . '.libraries.yml',
+    $kit . '.breakpoints.yml',
+    $kit . '.theme',
+    'README.md',
+  );
+}

--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -12,14 +12,14 @@ function emulsify_drush_command() {
   $items = array();
 
   $items['emulsify'] = array(
-    'description' => 'Create an Emulsify theme.',
+    'description' => 'Create an Emulsify-based theme.',
     'arguments' => array(
-      'name'         => 'The name of your theme.',
+      'human_readable_name'         => 'The name of your theme.',
     ),
     'options' => array(
       'machine_name' => 'The machine-readable name of your theme. This will be auto-generated from the human-readable name if ommited.',
       'description' => 'The description of your theme',
-      'path' => 'The destination of your theme. Defaults to "all" (themes).',
+      'path' => 'The destination of your theme. Defaults to "themes/custom".',
       'slim' => 'Only copy base files',
     ),
     'examples' => array(
@@ -44,23 +44,23 @@ function emulsify_drush_help($section) {
 /**
  * Implements drush_hook_COMMAND().
  */
-function drush_emulsify($name = NULL) {
+function drush_emulsify($human_readable_name = NULL) {
 
-  // If no $name provided, abort.
-  if (!$name) {
+  // If no $human_readable_name provided, abort.
+  if (!$human_readable_name) {
     drush_print(dt('Theme name missing. See help using drush emulsify --help.'));
     return;
   }
 
   // Determine the theme name.
-  if (!isset($name)) {
-    $name = drush_get_option('name');
+  if (!isset($human_readable_name)) {
+    $human_readable_name = drush_get_option('human_readable_name');
   }
 
   // Determine the machine name.
   $machine_name = drush_get_option('machine_name');
   if (!$machine_name) {
-    $machine_name = $name;
+    $machine_name = $human_readable_name;
   }
   $machine_name = str_replace(' ', '_', strtolower($machine_name));
   $search = array(
@@ -72,7 +72,7 @@ function drush_emulsify($name = NULL) {
   $machine_name = preg_replace($search, '', $machine_name);
 
   // Description of theme.
-  $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'Theme that uses Pattern Lab v2.';
+  $description = (drush_get_option('description')) ? trim(drush_get_option('description')) : 'Theme based on <a href="http://emulsify.info">Emulsify</a>.';
 
   // Determine the path to the new theme.
   $theme_path = 'themes/custom';
@@ -80,13 +80,13 @@ function drush_emulsify($name = NULL) {
     $theme_path = drush_trim_path($path);
   }
 
-  drush_emulsify_create($name, $machine_name, $description, $theme_path);
+  drush_emulsify_create($human_readable_name, $machine_name, $description, $theme_path);
 }
 
 /**
  * Create frontend theme.
  */
-function drush_emulsify_create($name, $machine_name, $description, $theme_path) {
+function drush_emulsify_create($human_readable_name, $machine_name, $description, $theme_path) {
   $theme_path = drush_normalize_path(drush_get_context('DRUSH_DRUPAL_ROOT') . '/' . $theme_path . '/' . $machine_name);
 
   if (!is_dir(dirname($theme_path))) {
@@ -98,7 +98,7 @@ function drush_emulsify_create($name, $machine_name, $description, $theme_path) 
   _emulsify_copy_files($files_to_copy, $theme_path);
 
   // Phase 2: Alter files.
-  $alterations = _emulsify_get_alterations($name, $machine_name);
+  $alterations = _emulsify_get_alterations($human_readable_name, $machine_name);
   $files_to_alter = _emulsify_get_files_to_alter();
   _emulsify_alter_files($theme_path, $files_to_alter, $alterations);
 
@@ -106,7 +106,7 @@ function drush_emulsify_create($name, $machine_name, $description, $theme_path) 
   $files_to_rename = _emulsify_get_files_to_rename();
   _emulsify_rename_files($theme_path, $machine_name, $files_to_rename);
 
-  _emulsify_notify($name, $theme_path);
+  _emulsify_notify($human_readable_name, $theme_path);
 }
 
 /**
@@ -116,9 +116,9 @@ function drush_emulsify_create($name, $machine_name, $description, $theme_path) 
  * happen in sequential order so you can replace something that was previously
  * replaced.
  */
-function _emulsify_get_alterations($name, $machine_name) {
+function _emulsify_get_alterations($human_readable_name, $machine_name) {
   return array(
-    'Emulsify' => $name,
+    'Emulsify' => $human_readable_name,
     'emulsify' => $machine_name,
     'hidden: true' => '',
   );
@@ -287,12 +287,12 @@ function _emulsify_file_str_replace($file_path, $find, $replace) {
 /**
  * Notifies the user of success.
  */
-function _emulsify_notify($name, $theme_path) {
+function _emulsify_notify($human_readable_name, $theme_path) {
   // Notify user of the newly created theme.
-  $message = 'Successfully created the Emulsify theme "!name" created in: !path, you can now run \'yarn\' or \'npm install\' to install the node modules.';
+  $message = 'Successfully created the Emulsify theme "!name" created in: !path, you can now run \'yarn\' or \'yarn install\' or \'npm install\' to install the node modules.';
 
   $message = dt($message, array(
-    '!name' => $name,
+    '!name' => $human_readable_name,
     '!path' => $theme_path,
   ));
   drush_print($message);

--- a/emulsify.drush.inc
+++ b/emulsify.drush.inc
@@ -110,7 +110,7 @@ function drush_emulsify_create($name, $machine_name, $description, $subtheme_pat
 }
 
 /**
- * Gets files to copy.
+ * Gets alterations (string replacements).
  *
  * This function supports both directories and individual files.  Alterations
  * happen in sequential order so you can replace something that was previously
@@ -154,6 +154,8 @@ function _emulsify_get_files_to_alter() {
  * This function supports both directories and individual files.
  *
  * The following directories/files will never be copied:
+ * css/
+ * dist/
  * node_modules/
  * github.com/
  * composer.json
@@ -180,8 +182,6 @@ function _emulsify_get_files_to_copy() {
   }
   else {
     return array_merge($slim_array, array(
-      'css',
-      'dist',
       'fonts',
       'images',
       'templates',
@@ -289,7 +289,7 @@ function _emulsify_file_str_replace($file_path, $find, $replace) {
  */
 function _emulsify_notify($name, $subtheme_path) {
   // Notify user of the newly created theme.
-  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path';
+  $message = 'Successfully created the Emulsify subtheme "!name" created in: !path, you can now run yarn to install the node modules.';
 
   $message = dt($message . '.', array(
     '!name' => $name,


### PR DESCRIPTION
## Purpose:
- Add basic drush script to create a subtheme

## Notes:
- Decided not to go with the "kit" approach and used the source directory.
- Edited the source files directly (we may need to replace more specific patterns if anything is broken)
- Added a `--slim` option to use a smaller number of files

## Testing:
- [x] Install a drupalvm D8 site
- [x] In the Emulsify theme directory run `yarn` to install
- [x] In Drupal, activate theme
- [x] `drush @drupalvm emulsify mysubtheme`
- [x] `npm i`
- [x] `npm start`
- [x] Verify that the subtheme appears in Drupal after a clear registry.

## Discussion Topics:
- Seems like the post install is working for pattern lab ... maybe we don't need this?