### PR TITLE
Attribute handling take 2

### DIFF
--- a/components/_patterns/01-atoms/01-links/link/link.twig
+++ b/components/_patterns/01-atoms/01-links/link/link.twig
@@ -15,13 +15,14 @@
 #}
 {% set link_base_class = link_base_class|default('link') %}
 
-<a
-  {{ bem(link_base_class, (link_modifiers), link_blockname, attributes) }}
-  {% for attribute,value in attributes %}
-    {{ attribute }}="{{ value }}"
-  {% endfor %}
-  href="{{ link_url }}"
->
+{% set additional_attributes = {
+  "class": bem(link_base_class, (link_modifiers), link_blockname),
+  "href": link_url
+} %}
+
+{% set additional_attributes = additional_attributes|merge(link_attributes) %}
+
+<a {{ render_attributes(additional_attributes) }} >
   {% block link_content %}
     {{ link_content }}
   {% endblock %}

--- a/components/_patterns/01-atoms/01-links/link/link.twig
+++ b/components/_patterns/01-atoms/01-links/link/link.twig
@@ -16,8 +16,8 @@
 {% set link_base_class = link_base_class|default('link') %}
 
 <a
-  {{ bem(link_base_class, (link_modifiers), link_blockname) }}
-  {% for attribute,value in link_attributes %}
+  {{ bem(link_base_class, (link_modifiers), link_blockname, attributes) }}
+  {% for attribute,value in attributes %}
     {{ attribute }}="{{ value }}"
   {% endfor %}
   href="{{ link_url }}"

--- a/components/_patterns/01-atoms/02-text/00-headings/_heading.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/_heading.twig
@@ -18,9 +18,11 @@
 #}
 {% set heading_base_class = heading_base_class|default('h' ~ heading_level) %}
 
-<h{{ heading_level }}
-  {{ bem(heading_base_class, (heading_modifiers), heading_blockname, attributes) }}
->
+{% set additional_attributes = {
+  "class": bem(heading_base_class, (heading_modifiers), heading_blockname)
+} %}
+
+<h{{ heading_level }} {{ render_attributes(additional_attributes) }}>
   {% if heading_url %}
     {% include "@atoms/01-links/link/link.twig" with {
       "link_content": heading,

--- a/components/_patterns/01-atoms/02-text/00-headings/_heading.twig
+++ b/components/_patterns/01-atoms/02-text/00-headings/_heading.twig
@@ -19,7 +19,7 @@
 {% set heading_base_class = heading_base_class|default('h' ~ heading_level) %}
 
 <h{{ heading_level }}
-  {{ bem(heading_base_class, (heading_modifiers), heading_blockname) }}
+  {{ bem(heading_base_class, (heading_modifiers), heading_blockname, attributes) }}
 >
   {% if heading_url %}
     {% include "@atoms/01-links/link/link.twig" with {

--- a/components/_patterns/03-organisms/_node.twig
+++ b/components/_patterns/03-organisms/_node.twig
@@ -71,8 +71,18 @@
  */
 #}
 
-{% set node_base_class = 'node' %}
-<article {{ bem(node_base_class, [], '', attributes) }}>
+{% set attributes = attributes.addClass('foo') %}
+
+{% set additional_attributes = {
+  "class": bem('node'),
+  "foo": [
+    "bar",
+    "baz"
+  ],
+  "beer": "mmmm"
+} %}
+
+<article {{ render_attributes(additional_attributes) }}>
 
   {{ title_prefix }}
   {% if not page %}
@@ -88,7 +98,7 @@
   {{ title_suffix }}
 
   {% if display_submitted %}
-    <footer>
+    <footer {{ bem('foo') }}>
       {{ author_picture }}
       <div{{ author_attributes }}>
         {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}

--- a/components/_patterns/03-organisms/_node.twig
+++ b/components/_patterns/03-organisms/_node.twig
@@ -71,15 +71,8 @@
  */
 #}
 
-{% set attributes = attributes.addClass('foo') %}
-
 {% set additional_attributes = {
-  "class": bem('node'),
-  "foo": [
-    "bar",
-    "baz"
-  ],
-  "beer": "mmmm"
+  "class": bem('node')
 } %}
 
 <article {{ render_attributes(additional_attributes) }}>
@@ -98,7 +91,7 @@
   {{ title_suffix }}
 
   {% if display_submitted %}
-    <footer {{ bem('foo') }}>
+    <footer>
       {{ author_picture }}
       <div{{ author_attributes }}>
         {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}

--- a/components/_patterns/03-organisms/_node.twig
+++ b/components/_patterns/03-organisms/_node.twig
@@ -70,13 +70,20 @@
  *   in different view modes.
  */
 #}
-<article{{ attributes }}>
+
+{% set node_base_class = 'node' %}
+<article {{ bem(node_base_class, [], '', attributes) }}>
 
   {{ title_prefix }}
   {% if not page %}
-    <h2{{ title_attributes.addClass('h2') }}>
-      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-    </h2>
+    {% include "@atoms/02-text/00-headings/_heading.twig" with {
+    "heading_level": 2,
+    "heading": label,
+    "heading_url": url,
+    "heading_link_attributes": {
+    'rel': 'bookmark'
+    },
+    } %}
   {% endif %}
   {{ title_suffix }}
 

--- a/components/_twig-components/functions/bem.function.php
+++ b/components/_twig-components/functions/bem.function.php
@@ -6,59 +6,7 @@
 
 use Drupal\Core\Template\Attribute;
 
-//$function = new Twig_SimpleFunction('bem', function ($base_class = '', $modifiers = array(), $blockname = '', $additional_classes = []) {
-//  $bem = [];
-//
-//  // If using a blockname to override default class.
-//  if ($blockname) {
-//    // Set blockname class.
-//    $bem[] = $blockname . '__' . $base_class;
-//
-//    // Set blockname--modifier classes for each modifier.
-//    if (isset($modifiers) && is_array($modifiers)) {
-//      foreach ($modifiers as $modifier) {
-//        $bem[] = $blockname . '__' . $base_class . '--' . $modifier;
-//      };
-//    }
-//  }
-//  // If not overriding base class.
-//  else {
-//    // Set base class.
-//    $bem[] = $base_class;
-//    // Set base--modifier class for each modifier
-//    if (isset($modifiers) && is_array($modifiers)) {
-//      foreach ($modifiers as $modifier) {
-//        $bem[] = $base_class . '--' . $modifier;
-//      };
-//    }
-//  }
-//
-//  if (!empty($additional_classes)) {
-//    foreach ($additional_classes as $additional_class) {
-//      $bem[] = $additional_class;
-//    }
-//  }
-//
-//  if (class_exists('Drupal')) {
-//    $classes = new Attribute();
-//
-//    if (!empty($bem)) {
-//      foreach ($bem as $class) {
-//        $classes->addClass($class);
-//      }
-//    }
-//
-//    return $classes;
-//  }
-//  else {
-//    $classString = implode(' ', $bem);
-//    $classesSafe = ' class="' . $classString . '"';
-//    return $classesSafe;
-//  }
-//
-//}, array('is_safe' => array('html')));
-
-$function = new Twig_SimpleFunction('bem', function ($context, $base_class = '', $modifiers = array(), $blockname = '', $attributes = []) {
+$function = new Twig_SimpleFunction('bem', function ($context, $base_class, $modifiers = array(), $blockname = '') {
   $classes = [];
 
   // If using a blockname to override default class.
@@ -77,7 +25,7 @@ $function = new Twig_SimpleFunction('bem', function ($context, $base_class = '',
   else {
     // Set base class.
     $classes[] = $base_class;
-    // Set base--modifier class for each modifier
+    // Set base--modifier class for each modifier.
     if (isset($modifiers) && is_array($modifiers)) {
       foreach ($modifiers as $modifier) {
         $classes[] = $base_class . '--' . $modifier;
@@ -85,19 +33,9 @@ $function = new Twig_SimpleFunction('bem', function ($context, $base_class = '',
     }
   }
 
-  // Add existing classes from attributes.
-  if (isset($attributes['class'])) {
-    foreach ($attributes['class'] as $class) {
-      $classes[] = $class;
-    }
-  }
-
   if (class_exists('Drupal')) {
-    if (!$attributes) {
-      $attributes = new Attribute();
-    }
+    $attributes = new Attribute();
 
-    // Set new or override existing class attribute.
     if (!empty($classes)) {
       $attributes->setAttribute('class', $classes);
     }
@@ -106,8 +44,7 @@ $function = new Twig_SimpleFunction('bem', function ($context, $base_class = '',
   }
   else {
     $classString = implode(' ', $classes);
-    $classesSafe = ' class="' . $classString . '"';
-    return $classesSafe;
+    return $classString;
   }
 
 }, array('needs_context' => true, 'is_safe' => array('html')));

--- a/components/_twig-components/functions/bem.function.php
+++ b/components/_twig-components/functions/bem.function.php
@@ -4,12 +4,16 @@
  * Add "bem" function for Pattern Lab & Drupal
  */
 
+use Drupal\Core\Template\Attribute;
+
 $function = new Twig_SimpleFunction('bem', function (Twig_Environment $env, $context, $base_class, $modifiers = array(), $blockname = '') {
-  $classes = array();
+  $classes = [];
+
   // If using a blockname to override default class.
   if ($blockname) {
     // Set blockname class.
     $classes[] = $blockname . '__' . $base_class;
+
     // Set blockname--modifier classes for each modifier.
     if (isset($modifiers) && is_array($modifiers)) {
       foreach ($modifiers as $modifier) {
@@ -29,12 +33,24 @@ $function = new Twig_SimpleFunction('bem', function (Twig_Environment $env, $con
     }
   }
 
-  $classString = implode(' ', $classes);
   if (class_exists('Drupal')) {
-    $context['attributes']->addClass($classString);
-    return $context['attributes'];
+    if (!isset($context['attributes'])) {
+      $attributes = new Attribute();
+    }
+    else {
+      $attributes = clone $context['attributes'];
+    }
+
+    if (!empty($classes)) {
+      foreach ($classes as $class) {
+        $attributes->addClass($class);
+      }
+    }
+
+    return $attributes;
   }
   else {
+    $classString = implode(' ', $classes);
     $classesSafe = ' class="' . $classString . '"';
     return $classesSafe;
   }

--- a/components/_twig-components/functions/bem.function.php
+++ b/components/_twig-components/functions/bem.function.php
@@ -6,7 +6,59 @@
 
 use Drupal\Core\Template\Attribute;
 
-$function = new Twig_SimpleFunction('bem', function (Twig_Environment $env, $context, $base_class, $modifiers = array(), $blockname = '') {
+//$function = new Twig_SimpleFunction('bem', function ($base_class = '', $modifiers = array(), $blockname = '', $additional_classes = []) {
+//  $bem = [];
+//
+//  // If using a blockname to override default class.
+//  if ($blockname) {
+//    // Set blockname class.
+//    $bem[] = $blockname . '__' . $base_class;
+//
+//    // Set blockname--modifier classes for each modifier.
+//    if (isset($modifiers) && is_array($modifiers)) {
+//      foreach ($modifiers as $modifier) {
+//        $bem[] = $blockname . '__' . $base_class . '--' . $modifier;
+//      };
+//    }
+//  }
+//  // If not overriding base class.
+//  else {
+//    // Set base class.
+//    $bem[] = $base_class;
+//    // Set base--modifier class for each modifier
+//    if (isset($modifiers) && is_array($modifiers)) {
+//      foreach ($modifiers as $modifier) {
+//        $bem[] = $base_class . '--' . $modifier;
+//      };
+//    }
+//  }
+//
+//  if (!empty($additional_classes)) {
+//    foreach ($additional_classes as $additional_class) {
+//      $bem[] = $additional_class;
+//    }
+//  }
+//
+//  if (class_exists('Drupal')) {
+//    $classes = new Attribute();
+//
+//    if (!empty($bem)) {
+//      foreach ($bem as $class) {
+//        $classes->addClass($class);
+//      }
+//    }
+//
+//    return $classes;
+//  }
+//  else {
+//    $classString = implode(' ', $bem);
+//    $classesSafe = ' class="' . $classString . '"';
+//    return $classesSafe;
+//  }
+//
+//}, array('is_safe' => array('html')));
+
+$function = new Twig_SimpleFunction('bem', function ($context, $base_class = '', $modifiers = array(), $blockname = '', $attributes = []) {
   $classes = [];
 
   // If using a blockname to override default class.
@@ -33,18 +85,21 @@ $function = new Twig_SimpleFunction('bem', function (Twig_Environment $env, $con
     }
   }
 
+  // Add existing classes from attributes.
+  if (isset($attributes['class'])) {
+    foreach ($attributes['class'] as $class) {
+      $classes[] = $class;
+    }
+  }
+
   if (class_exists('Drupal')) {
-    if (!isset($context['attributes'])) {
+    if (!$attributes) {
       $attributes = new Attribute();
     }
-    else {
-      $attributes = clone $context['attributes'];
-    }
 
+    // Set new or override existing class attribute.
     if (!empty($classes)) {
-      foreach ($classes as $class) {
-        $attributes->addClass($class);
-      }
+      $attributes->setAttribute('class', $classes);
     }
 
     return $attributes;
@@ -55,4 +110,4 @@ $function = new Twig_SimpleFunction('bem', function (Twig_Environment $env, $con
     return $classesSafe;
   }
 
-}, array('needs_context' => true, 'needs_environment' => true, 'is_safe' => array('html')));
+}, array('needs_context' => true, 'is_safe' => array('html')));

--- a/components/_twig-components/functions/render_attributes.function.php
+++ b/components/_twig-components/functions/render_attributes.function.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Add "bem" function for Pattern Lab & Drupal
+ * Add "render_attributes" function for Pattern Lab & Drupal
  */
 
 use Drupal\Core\Template\Attribute;
@@ -12,7 +12,7 @@ $function = new Twig_SimpleFunction('render_attributes', function ($context, $ad
 
     if (!empty($additional_attributes)) {
       foreach ($additional_attributes as $key => $value) {
-        // If value is an instance of Attribute(), get it's value.
+        // If value is an instance of Attribute(), get its value.
         if ($value instanceof Attribute && $value->offsetExists($key)) {
           $value = $value->offsetGet($key)->value();
         }
@@ -30,8 +30,8 @@ $function = new Twig_SimpleFunction('render_attributes', function ($context, $ad
     // Set all attributes.
     foreach($context['attributes'] as $key => $value) {
       $attributes->setAttribute($key, $value);
-      // Remove this attribute from context so it doesn't filter down to
-      // child elements.
+      // Remove this attribute from context so it doesn't filter down to child
+      // elements.
       $context['attributes']->removeAttribute($key);
     }
 

--- a/components/_twig-components/functions/render_attributes.function.php
+++ b/components/_twig-components/functions/render_attributes.function.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @file
+ * Add "bem" function for Pattern Lab & Drupal
+ */
+
+use Drupal\Core\Template\Attribute;
+
+$function = new Twig_SimpleFunction('render_attributes', function ($context, $additional_attributes = []) {
+  if (class_exists('Drupal')) {
+    $attributes = new Attribute();
+
+    if (!empty($additional_attributes)) {
+      foreach ($additional_attributes as $key => $value) {
+        // If value is an instance of Attribute(), get it's value.
+        if ($value instanceof Attribute && $value->offsetExists($key)) {
+          $value = $value->offsetGet($key)->value();
+        }
+
+        // Merge additional attribute values with existing ones.
+        if ($context['attributes']->offsetExists($key)) {
+          $existing_attribute = $context['attributes']->offsetGet($key)->value();
+          $value = array_merge($existing_attribute, $value);
+        }
+
+        $context['attributes']->setAttribute($key, $value);
+      }
+    }
+
+    // Set all attributes.
+    foreach($context['attributes'] as $key => $value) {
+      $attributes->setAttribute($key, $value);
+      // Remove this attribute from context so it doesn't filter down to
+      // child elements.
+      $context['attributes']->removeAttribute($key);
+    }
+
+    return $attributes;
+  }
+  else {
+    $attributes = [];
+
+    foreach ($additional_attributes as $key => $value) {
+      if (is_array($value)) {
+        $attributes[] = $key . '="' . implode(' ', $value) . '"';
+      }
+      else {
+        $attributes[] = $key . '="' . $value . '"';
+      }
+    }
+
+    return implode(' ', $attributes);
+  }
+
+}, array('needs_context' => true, 'is_safe' => array('html')));


### PR DESCRIPTION
@evanmwillhite here is essentially what I demoed for you earlier. I'm not 100% satisfied with it. I'd like it to work better with existing Twig methods for manipulating attributes. It already does sorta but not to the point it can do away with the `additional_attributes` object and still be able to produce the desired results. Also, as I mentioned, I'm not sure if there are any consequences for removing attributes from `$context['attributes']` like this does.