### PR TITLE
Use Drupal Pattern Lab's version of Pattern Lab

### DIFF
--- a/scripts/pattern_lab.sh
+++ b/scripts/pattern_lab.sh
@@ -4,8 +4,8 @@
 # Remove existing PL directory
 rm -rf pattern-lab
 
-# Install PL
-composer create-project -n pattern-lab/edition-twig-standard pattern-lab
+# Install PL using Drupal Pattern Lab's Edition: https://github.com/drupal-pattern-lab/edition-php-twig-standard
+composer create-project -n drupal-pattern-lab/edition-twig-standard pattern-lab
 
 # Delete the default source directory
 rm -rf pattern-lab/source


### PR DESCRIPTION
This will have Emulsify use [Drupal Pattern Lab's PL Edition](https://github.com/drupal-pattern-lab/edition-php-twig-standard) instead of [the original, abandoned PL Edition](https://github.com/pattern-lab/edition-php-twig-standard). This has lots of improvements over the old one and @evanmwillhite is a core maintainers of it as well (as am I along with @sghoweri).

Cheers; congrats on launching the new version! Happy Pattern Labbing!