### PR TITLE
Main Menu Fixes

### DIFF
--- a/components/_patterns/02-molecules/menus/_menu-item.twig
+++ b/components/_patterns/02-molecules/menus/_menu-item.twig
@@ -1,4 +1,6 @@
-{% set item_modifiers = [] %}
+{% if not item_modifiers %}
+  {% set item_modifiers = [] %}
+{% endif %}
 {% if item.in_active_trail == TRUE %}
   {% set item_modifiers = item_modifiers|merge(['active']) %}
 {% endif %}
@@ -8,6 +10,10 @@
 {% if item.below %}
   {% set item_modifiers = item_modifiers|merge(['with-sub']) %}
 {% endif %}
+{# below could maybe be done without a loop? #}
+{% for modifier in item.modifiers %}
+  {% set item_modifiers = item_modifiers|merge([modifier]) %}
+{% endfor %}
 
 {% embed "@atoms/03-lists/_list-item.twig" with {
   "list_item_label": item_label,

--- a/components/_patterns/02-molecules/menus/_menu.twig
+++ b/components/_patterns/02-molecules/menus/_menu.twig
@@ -26,7 +26,7 @@
 #}
 {{ menus.menu_links(items, attributes, 0, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname) }}
 
-{% macro menu_links(items, attributes, menu_level, menu_class, menu_modifiers, menu_blockname) %}
+{% macro menu_links(items, attributes, menu_level, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname) %}
   {% import _self as menus %}
   {% if items %}
 
@@ -47,7 +47,11 @@
     } %}
       {% block list_content %}
         {% for item in items %}
-          {% include "@molecules/menus/_menu-item.twig" %}
+          {% include "@molecules/menus/_menu-item.twig" with {
+            li_base_class: item_base_class,
+            li_modifiers: item_modifiers,
+            li_blockname: item_blockname,
+          } %}
         {% endfor %}
       {% endblock %}
     {% endembed %}

--- a/templates/block/block--mainnavigation.html.twig
+++ b/templates/block/block--mainnavigation.html.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+
+{# Label. If not displayed, we still provide it for screen readers. #}
+{% if not configuration.label_display %}
+  {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+{% endif %}
+{{ title_prefix }}
+{% include "@atoms/02-text/00-headings/_heading.twig" with {
+  "heading_level": 2,
+  "heading": label,
+} %}
+{{ title_suffix }}
+
+{# Menu. #}
+{% block content %}
+  {{ content }}
+{% endblock %}


### PR DESCRIPTION
Learning curve on client project provided:

1. Better handling of classes for inheritance. Basically, Drupal doesn't have a `<li>` level template, so we are including the outer element and need a way to pass classes into the child element. This method allows passing the `<ul>` modifiers and blockname to the `<li>`s.
2. Main menu files provide `<nav>` element so we need to override the default drupal file that provides its own