### PR TITLE
Image field link Attributes fix

### DIFF
--- a/components/_patterns/01-atoms/04-images/00-image/image.twig
+++ b/components/_patterns/01-atoms/04-images/00-image/image.twig
@@ -23,6 +23,7 @@
     "link_base_class": image_link_base_class,
     "link_modifiers": image_link_modifiers,
     "link_blockname": image_link_blockname,
+    "attributes": [],
   } %}
     {% block link_content %}
       <img


### PR DESCRIPTION
There is currently a bug where when using the image field in certain Drupal templates, the img_url link option will accidentally inherit the image's attribute values (e.g., when using it in Drupal's default image.html.twig file).

This additions clears the attributes object for that specific link instance (only within the image file) since we pass the options manually to that link anyway. 