### PR TITLE
Add conditional for button_url

### DIFF
--- a/components/_patterns/01-atoms/06-buttons/01-button.twig
+++ b/components/_patterns/01-atoms/06-buttons/01-button.twig
@@ -20,7 +20,7 @@
   {% for attribute,value in button_attributes %}
     {{ attribute }}="{{ value }}"
   {% endfor %}
-  {% if buttom_url %}
+  {% if button_url %}
     href="{{ button_url }}"
   {% endif %}
 >

--- a/components/_patterns/01-atoms/06-buttons/01-button.twig
+++ b/components/_patterns/01-atoms/06-buttons/01-button.twig
@@ -20,7 +20,9 @@
   {% for attribute,value in button_attributes %}
     {{ attribute }}="{{ value }}"
   {% endfor %}
-  href="{{ button_url }}"
+  {% if buttom_url %}
+    href="{{ button_url }}"
+  {% endif %}
 >
   {% block button_content %}
     {{ button_content }}


### PR DESCRIPTION
If a button is used in a place that doesn't require a href, such as a form, it shouldn't have an empty `href=""`. 