### PR TITLE
Base PL container max-width on %, not type size.

### DIFF
--- a/components/css/pattern-scaffolding.css
+++ b/components/css/pattern-scaffolding.css
@@ -7,7 +7,7 @@
 [role=main] {
   padding: .5rem .5rem 2rem;
   overflow: hidden;
-  max-width: 75em;
+  max-width: 90%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
As a follow up to #192, I'd like to submit this correction. Using `ems` as a width can result in the container blowing of the window if the base font size is changed. This will give us more consistent results independent of the font size.