### PR TITLE
Github Pages deployment fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore compiled files.
 dist
 vendor
+build
 
 # Pattern Lab (ignored initially)
 pattern-lab

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Project template for Drupal 8 themes",
   "version": "1.0.0",
   "devDependencies": {
-    "emulsify-gulp": "fourkitchens/emulsify-gulp#v2.0.0",
+    "emulsify-gulp": "fourkitchens/emulsify-gulp#pages-fix",
     "gulp": "^3.9.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Project template for Drupal 8 themes",
   "version": "1.0.0",
   "devDependencies": {
-    "emulsify-gulp": "fourkitchens/emulsify-gulp#pages-fix",
+    "emulsify-gulp": "fourkitchens/emulsify-gulp#v2.0.0",
     "gulp": "^3.9.1"
   },
   "scripts": {


### PR DESCRIPTION
Fixes github pages deployment script (`gulp ghpages-deploy`) by switching from gulp-gh-pages to gh-pages npm package. This PR merely ignores the build directory created by the script - the majority of the change is in https://github.com/fourkitchens/emulsify-gulp/pull/74

**To test:**
- [ ] Fork Emulsify and clone the new fork down locally 
- [ ] Open package.json and change `fourkitchens/emulsify-gulp#v2.0.0` to `fourkitchens/emulsify-gulp#pages-fix`
- [ ] `yarn install`
- [ ] `yarn start`
- [ ] `gulp ghpages-deploy`
- [ ] Verify the gh-pages branch was created and push to your repo and that in your repo's settings, you can navigate to the Github Pages url + `/pattern-lab/public` and view the Pattern Lab instance.