### PR TITLE
Make the trans tag, pattern lab only

### DIFF
--- a/components/_twig-components/tags/pl_trans.tag.php
+++ b/components/_twig-components/tags/pl_trans.tag.php
@@ -8,12 +8,12 @@
  */
 
 // These files are loaded three times and we can't re-set a class.
-if (!class_exists("Project_trans_Node")) {
+if (!class_exists("Project_pl_trans_Node")) {
 
   /**
    * Class Project_trans_Node.
    */
-  class Project_trans_Node extends \Twig_Node {
+  class Project_pl_trans_Node extends \Twig_Node {
 
     /**
      * {@inheritdoc}
@@ -148,12 +148,12 @@ if (!class_exists("Project_trans_Node")) {
 }
 
 // These files are loaded three times and we can't re-set a class.
-if (!class_exists("Project_trans_TokenParser")) {
+if (!class_exists("Project_pl_trans_TokenParser")) {
 
   /**
    * Class Project_trans_TokenParser.
    */
-  class Project_trans_TokenParser extends \Twig_TokenParser {
+  class Project_pl_trans_TokenParser extends \Twig_TokenParser {
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
_twig_components/tags/trans.tag.php show be PL specific only. The Unified twig extension module puts it into Drupal when it has its own