### PR TITLE
Added attach_library Twig function in PL

### DIFF
--- a/components/_patterns/01-atoms/04-images/icons/_icon.twig
+++ b/components/_patterns/01-atoms/04-images/icons/_icon.twig
@@ -10,7 +10,7 @@
 {% set icon_base_class = icon_base_class|default('icon') %}
 {% set icon_url = '' %}
 
-{# Drupal #}
+{# If using Drupal, you will want to uncomment the section below and set the path to match your theme. #}
 {# {% if attributes or theme_hook_original %}
   {% set icon_url = '/themes/custom/YOURTHEME/dist/img/sprite/' %}
   {{ attach_library('emulsify/sprite') }}

--- a/components/_patterns/01-atoms/04-images/icons/icons.md
+++ b/components/_patterns/01-atoms/04-images/icons/icons.md
@@ -1,13 +1,14 @@
 ---
 title: Icons
 ---
+
 ### How to use icons
 
 We are using a gulp SVG sprite generator (details [here](https://una.im/svg-icons)), which automatically creates the SVG in `/images/icons/sprite/sprite.svg`. Simply run `gulp icons` to add to the sprite.
 
 **Usage**
 
-The SVG component is found here: `/components/_patterns/01-atoms/04-images/icons/_icon.twig`. See available variables in that file. Examples of usage below:
+The SVG component is found here: `/components/_patterns/01-atoms/04-images/icons/_icon.twig`. See available variables in that file as well as instructions for Drupal. Examples of usage below:
 
 Simple: (no BEM renaming)
 

--- a/components/_twig-components/functions/pl_attach-library.function.php
+++ b/components/_twig-components/functions/pl_attach-library.function.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @file
+ * Add "kint" function for Pattern Lab.
+ */
+
+$function = new Twig_SimpleFunction('attach_library', function ($string) {
+  return $string;
+});

--- a/components/_twig-components/functions/pl_attach-library.function.php
+++ b/components/_twig-components/functions/pl_attach-library.function.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Add "kint" function for Pattern Lab.
+ * Add "attach_library" function for Pattern Lab.
  */
 
 $function = new Twig_SimpleFunction('attach_library', function ($string) {


### PR DESCRIPTION
If you want to use this in PL files (which we do in new icon file), this function has to be added to Pattern Lab's `_twig-components`

**How to test:**
1. Checkout this branch and run `yarn start` and make sure you get no errors
2. Bonus points: Ensure it causes no issues in Drupal (I tested this)