### PR TITLE
Fix help command output

### DIFF
--- a/emulsify.php
+++ b/emulsify.php
@@ -17,7 +17,7 @@ if ($argc < 2 || in_array($argv[1], array('--help', '-help', '-h', '-?'))) {
     print($option . " => " . $option_description . PHP_EOL);
   }
   print(PHP_EOL . "Examples" . PHP_EOL);
-  foreach ($command['options'] as $example => $example_description) {
+  foreach ($command['examples'] as $example => $example_description) {
     print($example . " => " . $example_description . PHP_EOL);
   }
   exit;


### PR DESCRIPTION
## Purpose:
- Follow up to this PR: https://github.com/fourkitchens/emulsify/pull/218
- Fix php script help command output (Examples section)
- The readme has already been updated so no changes necessary here

## Deployment:
- Push code

## Testing:
- Change directories into the theme directory
- Run `php emulsify.php -h`
- Notice this text before the change:
```
$ php emulsify.php -h
This command will create an Emulsify theme. See examples to get started.

Arguments
human_readable_name => The name of your theme.

Options
machine-name => The machine-readable name of your theme. This will be auto-generated from the human_readable_name if ommited.
description => The description of your theme
path => Supports three options contrib, custom, none.  Defaults to "custom".
slim => Only copy base files

Examples
machine-name => The machine-readable name of your theme. This will be auto-generated from the human_readable_name if ommited.
description => The description of your theme
path => Supports three options contrib, custom, none.  Defaults to "custom".
slim => Only copy base files
```
- Notice this text after the change:
```
$ php emulsify.php -h
This command will create an Emulsify theme. See examples to get started.

Arguments
human_readable_name => The name of your theme.

Options
machine-name => The machine-readable name of your theme. This will be auto-generated from the human_readable_name if ommited.
description => The description of your theme
path => Supports three options contrib, custom, none.  Defaults to "custom".
slim => Only copy base files

Examples
php emulsify.php "My Awesome Theme" => Creates an Emulsify theme called "My Awesome Theme", using the default options.
php emulsify.php "My Awesome Theme" --machine-name mat => Creates a Emulsify theme called "My Awesome Theme" with the specific machine name "mat".
```