### PR TITLE
Remove old PL CSS ref

### DIFF
--- a/components/_meta/_00-head.twig
+++ b/components/_meta/_00-head.twig
@@ -4,9 +4,7 @@
     <title>{{ title }}</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width" />
-
-    <!-- Pattern Lab base styles -->
-    <link rel="stylesheet" href="../../css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />
+    
     <!-- Component styles -->
     <link rel="stylesheet" href="../../../../dist/style.css?{{ cacheBuster }}" media="all" />
 


### PR DESCRIPTION
Pattern Lab still references the old `pattern-scaffolding.css` file that was removed in https://github.com/fourkitchens/emulsify/pull/236. This simply removes that unneeded line.