### PR TITLE
237: removed JS class on non-JS implementation

### DIFF
--- a/components/_patterns/01-atoms/09-menu/tab/_tab.scss
+++ b/components/_patterns/01-atoms/09-menu/tab/_tab.scss
@@ -1,4 +1,5 @@
-.tabs__link {
+.tabs__link,
+.tabs__link--local-tasks {
   background-color: $near-white;
   border: 1px solid $gray-lightest;
   border-bottom: none;

--- a/components/_patterns/01-atoms/09-menu/tab/tab.twig
+++ b/components/_patterns/01-atoms/09-menu/tab/tab.twig
@@ -17,7 +17,6 @@
 {%
   set link_classes = [
     is_active ? 'is-active',
-    'tabs__link',
     'tabs__link--local-tasks'
   ]
 %}


### PR DESCRIPTION
Fixes https://github.com/fourkitchens/emulsify/issues/237

- Removes tab class for non-JS (Drupal) implementations like local tasks.
- Adds styling to both classes so they look the same