### PR TITLE
244: Remove Singularity

### DIFF
--- a/components/_patterns/00-base/global/base/_02-breakpoints.scss
+++ b/components/_patterns/00-base/global/base/_02-breakpoints.scss
@@ -4,11 +4,6 @@
  *
  */
 
-/////////
-// Singularity variables
-//
-@include breakpoint-set('to ems', true);
-
 /////////////////////
 // Global Breakpoints
 

--- a/components/_patterns/00-base/global/base/_02-breakpoints.scss
+++ b/components/_patterns/00-base/global/base/_02-breakpoints.scss
@@ -8,8 +8,6 @@
 // Singularity variables
 //
 @include breakpoint-set('to ems', true);
-@include add-grid(12);
-@include add-gutter(1/4);
 
 /////////////////////
 // Global Breakpoints

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -2,6 +2,9 @@
 // General Layout (example code)
 //
 
+$sidebar-width: 33%;
+$gutter: 2%;
+
 .layout-container {
   @include wrapper;
 }
@@ -14,20 +17,30 @@
   margin-bottom: 4em;
 }
 
-.main-sidebar {
+.main {
   @include large {
-    @include grid-span(3,9);
+    display: flex;
+  }
+}
+
+.main-sidebar {
+  margin-bottom: $space-double;
+
+  @include large {
+    order: 2;
+    width: $sidebar-width;
   }
 }
 
 .main-content {
-  padding: 0 1em;
+  width: 100%;
 
   @include large {
     padding: 0;
 
     &--with-sidebar {
-      @include grid-span(8,1);
+      margin-right: $gutter;
+      width: 100 - ($sidebar-width + $gutter);
     }
   }
 }

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -4,6 +4,7 @@
 
 $sidebar-width: 33%;
 $gutter: 2%;
+$main-width: 100 - ($sidebar-width + $gutter);
 
 .layout-container {
   @include wrapper;
@@ -17,6 +18,7 @@ $gutter: 2%;
   margin-bottom: 4em;
 }
 
+// Layout Using Flexbox (IE11+)
 .main {
   @include large {
     display: flex;
@@ -24,6 +26,7 @@ $gutter: 2%;
 }
 
 .main-sidebar {
+  grid-area: sidebar;
   margin-bottom: $space-double;
 
   @include large {
@@ -33,14 +36,35 @@ $gutter: 2%;
 }
 
 .main-content {
+  grid-area: content;
   width: 100%;
 
   @include large {
-    padding: 0;
-
     &--with-sidebar {
       margin-right: $gutter;
-      width: 100 - ($sidebar-width + $gutter);
+      width: $main-width;
     }
   }
 }
+
+// Layout Using CSS Grid (NO IE11 support)
+// .main {
+//   &--with-sidebar {
+//     @include large {
+//       display: grid;
+//       grid-gap: 2%;
+//       grid-template-areas: "content sidebar";
+//       grid-template-columns: $main-width $sidebar-width;
+//     }
+//   }
+// }
+//
+// .main-sidebar {
+//   grid-area: sidebar;
+//   margin-bottom: $space-double;
+// }
+//
+// .main-content {
+//   grid-area: content;
+//   width: 100%;
+// }

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -30,6 +30,7 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
   @include large {
     order: 2;
     width: $sidebar-width;
+    margin-bottom: 0;
   }
 }
 

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -18,6 +18,7 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 // Layout Using Flexbox (IE11+).
 // Remove this and uncomment Grid code below to use CSS Grid.
 //
+
 .main {
   @include large {
     display: flex;
@@ -25,7 +26,7 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 }
 
 .main-sidebar {
-  margin-bottom: $gutter;
+  margin-bottom: $space-double;
 
   @include large {
     order: 2;
@@ -35,6 +36,8 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 }
 
 .main-content {
+  width: 100%;
+
   @include large {
     &--with-sidebar {
       margin-right: $gutter;
@@ -58,12 +61,12 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 //     }
 //   }
 // }
-
+//
 // .main-sidebar {
 //   grid-area: sidebar;
-//   margin-bottom: $gutter;
+//   margin-bottom: $space-double;
 // }
-
+//
 // .main-content {
 //   grid-area: content;
 //   width: 100%;

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -4,7 +4,7 @@
 
 $sidebar-width: 33%;
 $gutter: $space;
-$main-width: 100 - ($sidebar-width + #{$gutter});
+$main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 
 .header,
 .main,
@@ -53,18 +53,18 @@ $main-width: 100 - ($sidebar-width + #{$gutter});
 //   &--with-sidebar {
 //     @include large {
 //       display: grid;
-//       grid-gap: 2%;
+//       grid-gap: $gutter;
 //       grid-template-areas: "content sidebar";
-//       grid-template-columns: $main-width $sidebar-width;
+//       grid-template-columns: $main-width #{$sidebar-width};
 //     }
 //   }
 // }
-//
+
 // .main-sidebar {
 //   grid-area: sidebar;
-//   margin-bottom: $space-double;
+//   margin-bottom: $gutter;
 // }
-//
+
 // .main-content {
 //   grid-area: content;
 //   width: 100%;

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -1,5 +1,5 @@
 //
-// General Layout (example code)
+// General Layout
 //
 
 $sidebar-width: 33%;
@@ -18,7 +18,10 @@ $main-width: 100 - ($sidebar-width + $gutter);
   margin-bottom: 4em;
 }
 
-// Layout Using Flexbox (IE11+)
+//
+// Layout Using Flexbox (IE11+).
+// Remove this and uncomment Grid code below to use CSS Grid.
+//
 .main {
   @include large {
     display: flex;
@@ -47,7 +50,11 @@ $main-width: 100 - ($sidebar-width + $gutter);
   }
 }
 
+//
 // Layout Using CSS Grid (NO IE11 support)
+// Remove Flexbox code above and uncomment this section to use CSS Grid.
+//
+
 // .main {
 //   &--with-sidebar {
 //     @include large {

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -35,8 +35,6 @@ $main-width: calc(100% - (#{$sidebar-width} + #{$gutter}));
 }
 
 .main-content {
-  width: 100%;
-
   @include large {
     &--with-sidebar {
       margin-right: $gutter;

--- a/components/_patterns/00-base/layouts/_default.scss
+++ b/components/_patterns/00-base/layouts/_default.scss
@@ -3,12 +3,8 @@
 //
 
 $sidebar-width: 33%;
-$gutter: 2%;
-$main-width: 100 - ($sidebar-width + $gutter);
-
-.layout-container {
-  @include wrapper;
-}
+$gutter: $space;
+$main-width: 100 - ($sidebar-width + #{$gutter});
 
 .header,
 .main,
@@ -29,8 +25,7 @@ $main-width: 100 - ($sidebar-width + $gutter);
 }
 
 .main-sidebar {
-  grid-area: sidebar;
-  margin-bottom: $space-double;
+  margin-bottom: $gutter;
 
   @include large {
     order: 2;
@@ -39,7 +34,6 @@ $main-width: 100 - ($sidebar-width + $gutter);
 }
 
 .main-content {
-  grid-area: content;
   width: 100%;
 
   @include large {

--- a/components/_patterns/05-pages/article/article.twig
+++ b/components/_patterns/05-pages/article/article.twig
@@ -5,13 +5,11 @@
 } %}
 
   {% block page_content %}
-    {% if site_title %}
-      {% include "@atoms/02-text/00-headings/_heading.twig" with {
-        "heading_level": 1,
-        "heading": 'This is a Real Article',
-        "heading_modifiers": ["margin"],
-      } %}
-    {% endif %}
+    {% include "@atoms/02-text/00-headings/_heading.twig" with {
+      "heading_level": 1,
+      "heading": 'This is a Real Article',
+      "heading_modifiers": ["margin"],
+    } %}
 
     {% include "@atoms/02-text/text/01-paragraph.twig" with {
       paragraph_content: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."

--- a/components/_patterns/style.scss
+++ b/components/_patterns/style.scss
@@ -1,8 +1,6 @@
 // Start libs
 // Better style reset
 @import "normalize";
-// Grid system, https://github.com/at-import/Singularity
-@import "singularitygs/stylesheets/singularitygs";
 // A cleaner way to do breakpoints/media queries, http://breakpoint-sass.com/
 @import "breakpoint-sass/stylesheets/breakpoint";
 // End libs


### PR DESCRIPTION
Addresses https://github.com/fourkitchens/emulsify/issues/244

Along with https://github.com/fourkitchens/emulsify-gulp/pull/78, this PR removes singularity for layout and replaces it with a flexbox implementation with a CSS Grid one commented out.

**What it does**
1. Removes singularity references and implementation in main layout file
2. Implements a simple flexbox layout instead
3. Adds a CSS Grid layout that is commented out

**To Test**
1. Checkout this branch and link the Emulsify Gulp instance with the corresponding branch
2. View the [sidebar template](http://localhost:3000/pattern-lab/public/?p=templates-with-sidebar) and [full-width template](http://localhost:3000/pattern-lab/public/?p=templates-full-width) and ensure content is displayed correctly at all screen sizes