### PR TITLE
icon path fix

### DIFF
--- a/components/_patterns/01-atoms/04-images/icons/_icon.twig
+++ b/components/_patterns/01-atoms/04-images/icons/_icon.twig
@@ -15,5 +15,5 @@
 {{ attach_library('emulsify/sprite') }}
 
 <svg {{ bem(icon_base_class, (icon_modifiers), icon_blockname, (icon_js_class)) }}>
-  <use xlink:href="{{ icon_url }}sprite.svg#{{ icon_name }}"></use>
+  <use xlink:href="{{ icon_url }}sprite.svg#icons--src--{{ icon_name }}"></use>
 </svg>


### PR DESCRIPTION
Fixes https://github.com/fourkitchens/emulsify/issues/255 and requires [this companion PR](https://github.com/fourkitchens/emulsify-gulp/pull/80) in Emulsify-Gulp. 

This PR specifically uses the new icon notation which includes the path of the icon itself.