### PR TITLE
eliminating horizontal bar by switching to CSS Grid

### DIFF
--- a/components/_patterns/00-base/global/base/_03-mixins.scss
+++ b/components/_patterns/00-base/global/base/_03-mixins.scss
@@ -20,24 +20,6 @@
   width: 100%;
   margin: #{$v-margin} auto;
   padding: #{$v-padding} #{$h-padding};
-
-  @include breakpoint($outer-container-break) {
-    padding: #{$v-padding} #{$h-padding-large};
-  }
-
-  @include breakpoint($container-max-width) {
-    padding-left: calc(#{$h-padding-large} + calc(-50vw + calc(#{$container-max-width} / 2)));
-    padding-right: calc(#{$h-padding-large} + calc(-50vw + calc(#{$container-max-width} / 2)));
-  }
-}
-
-/// Use the breakout mixin for elements that should be edge-to-edge
-/// Even when a parent container uses the wrapper mixin
-@mixin breakout($v-padding: $space-double) {
-  margin-left: calc(-50vw + 50%);
-  margin-right: calc(-50vw + 50%);
-  padding-left: calc(#{$v-padding} + calc(-50vw + 50%));
-  padding-right: calc(#{$v-padding} + calc(-50vw + 50%));
 }
 
 /// Mixin - Standard Margin

--- a/components/_patterns/00-base/global/base/_pl-base.scss
+++ b/components/_patterns/00-base/global/base/_pl-base.scss
@@ -1,10 +1,6 @@
 // These styles are specifically for Pattern Lab.
 // They are not used by the site in any way.
 
-.sg-main {
-  @include wrapper;
-}
-
 .pl-template {
   display: flex;
   flex-flow: column nowrap;
@@ -16,7 +12,6 @@
     font-size: 3rem;
     text-transform: uppercase;
     background-color: $gray-darker;
-    margin: 0 calc(-50vw + 50%) $space calc(-50vw + 50%);
 
     a {
       @include wrapper(
@@ -79,4 +74,17 @@
       margin-bottom: 0.3em;
     }
   }
+}
+
+#sg-patterns {
+  display: grid;
+  grid-template-columns: [full-start] minmax(1em, 1fr) [main-start] minmax(0, $max-width) [main-end] minmax(1em, 1fr) [full-end];
+}
+
+#sg-patterns > * {
+  grid-column: main;
+}
+
+#sg-patterns > .sg-subtype {
+  grid-column: full;
 }

--- a/components/_patterns/00-base/global/base/_pl-base.scss
+++ b/components/_patterns/00-base/global/base/_pl-base.scss
@@ -12,12 +12,13 @@
     font-size: 3rem;
     text-transform: uppercase;
     background-color: $gray-darker;
+    margin: 0;
 
     a {
       @include wrapper(
-        $v-padding: $space
+        $v-padding: $space,
+        $h-padding: 0
       );
-
       display: block;
       color: $white;
       text-decoration: none;

--- a/components/_patterns/01-atoms/05-forms/textfields/_textfields.scss
+++ b/components/_patterns/01-atoms/05-forms/textfields/_textfields.scss
@@ -20,6 +20,7 @@
 .form-item__textfield {
   border: 1px solid $gray-lightest;
   padding: 0.6em;
+  max-width: 100%;
 
   &:focus {
     border-color: $black;


### PR DESCRIPTION
This is fixing #261 by switching to CSS Grid
+ fixing text input fields in the forms that are too wide on narrow screens