### PR TITLE
Replacing <button> element with <a href> whenever there's a link

### DIFF
--- a/components/_patterns/01-atoms/06-buttons/01-button.twig
+++ b/components/_patterns/01-atoms/06-buttons/01-button.twig
@@ -15,25 +15,13 @@
 #}
 {% set button_base_class = button_base_class|default('button') %}
 
-{% if button_url %}
-    {{ "<a" }}
-{% else %}
-    {{ "<button" }}
-{% endif %}
-
+<button
   {{ bem(button_base_class, (button_modifiers), button_blockname) }}
   {% for attribute,value in button_attributes %}
     {{ attribute }}="{{ value }}"
   {% endfor %}
-  {% if button_url %}
-    href="{{ button_url }}"
-  {% endif %}
-  {{ ">" }}
+>
   {% block button_content %}
-    {{ button_content }}
+      {{ button_content }}
   {% endblock %}
-{% if button_url %}
-  {{ "</a>" }}
-{% else %}
-  {{ "</button>" }}
-{% endif %}
+</button>

--- a/components/_patterns/01-atoms/06-buttons/01-button.twig
+++ b/components/_patterns/01-atoms/06-buttons/01-button.twig
@@ -22,6 +22,6 @@
   {% endfor %}
 >
   {% block button_content %}
-      {{ button_content }}
+    {{ button_content }}
   {% endblock %}
 </button>

--- a/components/_patterns/01-atoms/06-buttons/01-button.twig
+++ b/components/_patterns/01-atoms/06-buttons/01-button.twig
@@ -15,7 +15,12 @@
 #}
 {% set button_base_class = button_base_class|default('button') %}
 
-<button
+{% if button_url %}
+    {{ "<a" }}
+{% else %}
+    {{ "<button" }}
+{% endif %}
+
   {{ bem(button_base_class, (button_modifiers), button_blockname) }}
   {% for attribute,value in button_attributes %}
     {{ attribute }}="{{ value }}"
@@ -23,8 +28,12 @@
   {% if button_url %}
     href="{{ button_url }}"
   {% endif %}
->
+  {{ ">" }}
   {% block button_content %}
     {{ button_content }}
   {% endblock %}
-</button>
+{% if button_url %}
+  {{ "</a>" }}
+{% else %}
+  {{ "</button>" }}
+{% endif %}


### PR DESCRIPTION
Resolving #263.

If there is a link inside the button, it switches it into <a> element, because it only needs to look like a button but behave like a link.
I added twig brackets to print partial elements {{ "<a" }}, because it seemed a "cleaner" way of doing it, but the same result can be achieved without these brackets.