### PR TITLE
Adding a default color to inline menu link

### DIFF
--- a/components/_patterns/02-molecules/menus/inline-menu/_inline-menu.scss
+++ b/components/_patterns/02-molecules/menus/inline-menu/_inline-menu.scss
@@ -16,6 +16,8 @@
 }
 
 .inline-menu__link {
+  @include link;
+  
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 1.5px;


### PR DESCRIPTION
(This is affecting links at the footer, that otherwise get the default blue color from the browser)