### PR TITLE
Moved Drupal components dependency from composer to .info file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         }
     },
     "require": {
-        "drupal/components": "^1.0",
         "drupal-pattern-lab/add-attributes-twig-extension": "^1.0",
         "drupal-pattern-lab/bem-twig-extension": "^1.0",
         "drupal-pattern-lab/attach-library-twig-extension": "^1.0",

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -3,6 +3,8 @@ type: theme
 description: Theme that uses Pattern Lab v2
 base theme: stable
 core: 8.x
+dependencies:
+  - components
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:


### PR DESCRIPTION
As of Drupal core 8.6.x, [themes can now declare dependencies](https://www.drupal.org/node/2937955)! Since the composer installation method was causing problems (Drupal being installed incorrectly in Emulsify's vendor directory since it is a requirement of the components module), we are moving the dependency to `emulsify.info.yml` and are going to make the instructions clear in the wiki/readme for those installing on older versions of Drupal.

To Test:
- [ ] Verify in a Drupal installation that installing Emulsify correctly installs the components module and the theme works when enabled per our instructions.
- [ ] Verify the readme/wiki are clear on the dependency and how to install for older versions.