### PR TITLE
Default to border-box; Fix linting

### DIFF
--- a/components/_patterns/00-base/global/base/_04-base.scss
+++ b/components/_patterns/00-base/global/base/_04-base.scss
@@ -1,3 +1,13 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::after,
+*::before {
+  box-sizing: inherit;
+}
+
 .main {
   @include wrapper;
 

--- a/components/_patterns/02-molecules/menus/inline-menu/_inline-menu.scss
+++ b/components/_patterns/02-molecules/menus/inline-menu/_inline-menu.scss
@@ -17,7 +17,7 @@
 
 .inline-menu__link {
   @include link;
-  
+
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 1.5px;


### PR DESCRIPTION
This PR resolves #297.

## How to review
- [x] `npm run start` and confirm that the default display uses `box-sizing: border-box;`.

_Why aren't any of the components impacted?_ Because Pattern Lab already applies border-box.