### PR TITLE
Pass document as the value of context to Drupal.attachBehaviors

### DIFF
--- a/components/_meta/_01-foot.twig
+++ b/components/_meta/_01-foot.twig
@@ -13,7 +13,7 @@
   <!-- <script src="../../js/drupal.js"></script> -->
 
   <!-- If using Drupal.behaviors, uncomment for them to work in Pattern Lab -->
-  <!-- <script>Drupal.attachBehaviors();</script> -->
+  <!-- <script>Drupal.attachBehaviors(document);</script> -->
 
   </body>
 </html>


### PR DESCRIPTION
If we don't pass a value for context then things like `$('[data-video]', context)` in Drupal behaviors won't work, and code won't be shareable between Drupal and PL.