### PR TITLE
Removing manual install of composer to check if we even need it anymore.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,6 @@ jobs:
             - ./pattern-lab
           key: v1-dependencies-npm-{{ checksum "package.json" }}
 
-      # Install Composer
-      # - run: php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-      # - run: php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-      # - run: php composer-setup.php
-      # - run: php -r "unlink('composer-setup.php');"
-
       # Install Drupal Dependencies
       # Found on this post:
       # https://discuss.circleci.com/t/installing-php7-1-gd-on-the-php-7-1-4-apache-container/14570

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ jobs:
           key: v1-dependencies-npm-{{ checksum "package.json" }}
 
       # Install Composer
-      - run: php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-      - run: php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-      - run: php composer-setup.php
-      - run: php -r "unlink('composer-setup.php');"
+      # - run: php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+      # - run: php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+      # - run: php composer-setup.php
+      # - run: php -r "unlink('composer-setup.php');"
 
       # Install Drupal Dependencies
       # Found on this post:


### PR DESCRIPTION
The docker box we are using should have composer installed. Creating a PR to confirm this and then do an alternate install method if we still do.

Testing this is a bit more difficult, but you can see that tests run successfully with the composer step removed.