### PR TITLE
222: removed inheritance of ALL item modifiers

### DIFF
--- a/components/_patterns/02-molecules/menus/_menu-item.twig
+++ b/components/_patterns/02-molecules/menus/_menu-item.twig
@@ -1,6 +1,8 @@
 {% if not item_modifiers %}
   {% set item_modifiers = [] %}
 {% endif %}
+{# Pass original item modifiers down to children #}
+{% set original_item_modifiers = item_modifiers %}
 {% if item.in_active_trail == TRUE %}
   {% set item_modifiers = item_modifiers|merge(['active']) %}
 {% endif %}
@@ -30,7 +32,7 @@
     } %}
     {% if item.below %}
       <span class="expand-sub"></span>
-      {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname) }}
+      {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_class, menu_modifiers, menu_blockname, item_base_class, original_item_modifiers, item_blockname) }}
     {% endif %}
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
## #222: Children menu items incorrectly inheriting ALL item modifiers

**Description:**
Implements the great patch proposed in https://github.com/fourkitchens/emulsify/issues/222#issue-320862096 to ensure original menu item modifiers get passed down but not ones that are specific to a specific level (e.g., `main-menu__item--with-sub`)

**To review:**
- Before checking out this branch, view the source of the [Main Menu](http://localhost:3000/pattern-lab/public/?p=molecules-main-menu) and verify that every dropdown child incorrectly has the class `main-menu__item--with-sub`
- Checkout this branch and verify that only the dropdown items _with_ a dropdown below them have that class.