### PR TITLE
323: Menu links to use link function

### DIFF
--- a/components/_patterns/02-molecules/menus/_menu-item.twig
+++ b/components/_patterns/02-molecules/menus/_menu-item.twig
@@ -24,12 +24,13 @@
   "li_blockname": item_blockname,
 } %}
   {% block list_item_content %}
-    {% include "@atoms/01-links/link/link.twig" with {
-      "link_content": item.title,
-      "link_url": item.url,
-      "link_base_class": item_base_class|default(menu_class ~ '__link'),
-      "link_modifiers": item_modifiers,
+    {# Any icons, etc. can go inside this set link_title statement. #}
+    {% set link_title %}{{ item.title }}{% endset %}
+    {# Put any other attributes besides class inside this set link_attributes. #}
+    {% set link_attributes = {
+      class: bem(item_base_class|default(menu_class ~ '__link'), (item_modifiers)),
     } %}
+    {{ link(link_title, item.url, add_attributes(link_attributes)) }}
     {% if item.below %}
       <span class="expand-sub"></span>
       {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_class, menu_modifiers, menu_blockname, item_base_class, original_item_modifiers, item_blockname) }}

--- a/components/_patterns/02-molecules/menus/_menu-item.twig
+++ b/components/_patterns/02-molecules/menus/_menu-item.twig
@@ -26,7 +26,7 @@
   {% block list_item_content %}
     {# Any icons, etc. can go inside this set link_title statement. #}
     {% set link_title %}{{ item.title }}{% endset %}
-    {# Put any other attributes besides class inside this set link_attributes. #}
+    {# You can add other attributes (id, etc.) inside this link_attributes array. #}
     {% set link_attributes = {
       class: bem(item_base_class|default(menu_class ~ '__link'), (item_modifiers)),
     } %}

--- a/components/_twig-components/functions/pl_link.function.php
+++ b/components/_twig-components/functions/pl_link.function.php
@@ -1,9 +1,27 @@
 <?php
 /**
  * @file
- * Add "link" function for Pattern Lab.
+ * Simple "link" function for Pattern Lab to replicate Drupal functionality.
  */
 
-$function = new Twig_SimpleFunction('link', function ($string) {
-  return $string;
-});
+$function = new Twig_SimpleFunction('link', function ($title, $url, $attributes = array()) {
+  // Make it into an array if it is not already.
+  if (!is_array($attributes)) {
+    $attributes = [$attributes];
+  }
+
+  $attributes_string = '';
+
+  // Create attributes.
+  if (isset($attributes) && is_array($attributes)) {
+    foreach ($attributes as $key => $value) {
+      // handle BEM function differently than rest.
+      if ($key == 'class') {
+        $attributes_string .= $value . ' ';
+      } else {
+        $attributes_string .= $key . '="' . $value . '" ';
+      }
+    };
+  }
+  return '<a href="' . $url . '"' . $attributes_string . '>' . $title . '</a>';
+}, array('is_safe' => array('html')));


### PR DESCRIPTION
Addresses https://github.com/fourkitchens/emulsify/issues/323

Because of how menu links are handled in Drupal outside of templates, we have to use the `link` function to get the full goodness of Drupal's link handling. This switches the menu-item tpl to use that function and creates a simple link function in Pattern Lab to mimic the behavior.

**To Test**:
- [ ] Checkout this branch and rerun `yarn start`
- [ ] Verify menus work correctly and look the same in both Pattern Lab AND Drupal.